### PR TITLE
[S1 C1 UV1] fix UI 识别选中

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Pomotention",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pomotention"
-version = "0.6.5"
+version = "0.6.6"
 description = "A focus enhancement software to help you stay present and love yourself"
 authors = ["xeonilian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/v2.json",
   "productName": "pomotention",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "com.pomotention.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/ActivitySheet/ActivityButtons.vue
+++ b/src/components/ActivitySheet/ActivityButtons.vue
@@ -6,7 +6,7 @@
   <div class="activity-view-button-container">
     <n-button
       @click="$emit('pick-activity')"
-      :disabled="activeId === undefined || props.isDeleted || isSelectedRowDone || noSelectedActivity"
+      :disabled="props.isDeleted || isSelectedRowDone || noSelectedActivity"
       circle
       secondary
       type="default"
@@ -19,7 +19,7 @@
     </n-button>
 
     <n-button
-      :title="props.isDeleted && activeId !== null && activeId !== undefined ? '恢复活动' : '删除活动'"
+      :title="props.isDeleted && effectiveActivityId != null ? '恢复活动' : '删除活动'"
       @click="$emit('delete-active')"
       circle
       secondary
@@ -29,7 +29,7 @@
     >
       <template #icon>
         <n-icon>
-          <DeleteDismiss24Regular v-if="props.isDeleted && activeId !== null" />
+          <DeleteDismiss24Regular v-if="props.isDeleted && effectiveActivityId != null" />
           <Delete24Regular v-else />
         </n-icon>
       </template>
@@ -42,7 +42,7 @@
       type="default"
       size="small"
       title="生成子活动"
-      :disabled="props.activeId === null || isSelectedRowDone || isSelectedClassS || props.isDeleted || noSelectedActivity"
+      :disabled="isSelectedRowDone || isSelectedClassS || props.isDeleted || noSelectedActivity"
       @click="() => emit('create-child-activity')"
     >
       <template #icon>
@@ -56,7 +56,7 @@
       circle
       size="small"
       title="升级为兄弟"
-      :disabled="props.activeId === null || isSelectedClassS"
+      :disabled="effectiveActivityId == null || isSelectedClassS"
       @click="() => emit('increase-child-activity')"
     >
       <template #icon>
@@ -112,7 +112,13 @@ const props = defineProps<{
 
 const dataStore = useDataStore();
 const { selectedRowId, selectedActivityId } = storeToRefs(dataStore);
-const noSelectedActivity = computed(() => selectedRowId.value == null && selectedActivityId.value == null);
+/** 看板 props.activeId 与仅 selectedActivityId 时有其一即视为选中活动 */
+const effectiveActivityId = computed(() => {
+  const a = props.activeId;
+  if (a != null && a !== undefined) return a;
+  return selectedActivityId.value;
+});
+const noSelectedActivity = computed(() => selectedRowId.value == null && selectedActivityId.value == null && props.activeId == null);
 
 const isSelectedClassS = computed(() => {
   return props.selectedClass === "S";

--- a/src/components/ActivitySheet/ActivitySection.vue
+++ b/src/components/ActivitySheet/ActivitySection.vue
@@ -21,7 +21,11 @@
         class="input-focus-none search-input"
       >
         <template #prefix>
-          <n-dropdown :options="filterOptions" @select="(key) => $emit('filter', key)">
+          <n-dropdown
+            :options="filterOptions"
+            @select="(key) => $emit('filter', key)"
+            @update:show="(show: boolean) => show && $emit('focus-search')"
+          >
             <n-button text type="default" title="筛选活动" @pointerdown.stop @mousedown.prevent.stop @touchstart.stop>
               <template #icon>
                 <n-icon><DocumentTableSearch24Regular /></n-icon>
@@ -371,6 +375,8 @@ import {
   Tag16Regular,
 } from "@vicons/fluent";
 import type { Activity } from "@/core/types/Activity";
+import { storeToRefs } from "pinia";
+import { useDataStore } from "@/stores/useDataStore";
 import { useSettingStore } from "@/stores/useSettingStore";
 import { useActivityTagEditor } from "@/composables/useActivityTagEditor";
 import { useActivityDrag } from "@/composables/useActivityDrag";
@@ -424,6 +430,26 @@ const { isTouchSupported } = useDevice();
 // ======================== Stores ========================
 const settingStore = useSettingStore();
 const { isMobile } = useDevice();
+
+// 手测用：每种交互最多打一条，避免 title-focus + before + after 重复刷屏（稳定后可删本段与调用）
+const {
+  activeId: storeActiveId,
+  selectedActivityId: storeSelectedActivityId,
+  selectedRowId: storeSelectedRowId,
+  selectedRowHasParent: storeSelectedRowHasParent,
+} = storeToRefs(useDataStore());
+
+function debugLogRowSelection(phase: string, rowId: number) {
+  const row = props.displaySheet.find((a) => a.id === rowId);
+  const hl = rowId === props.activityId || rowId === props.activeId;
+  const miss = !row;
+  console.log(
+    `[ActivitySection] ${phase} | sec=${props.sectionId} row=${rowId} | ` +
+      `del=${miss ? "?" : row!.deleted} par=${miss ? "?" : row!.parentId} st=${miss ? "?" : row!.status || "∅"} | ` +
+      `hl=${hl} props(act=${props.activityId},active=${props.activeId ?? "null"}) | ` +
+      `store(act=${storeActiveId.value},selAct=${storeSelectedActivityId.value},rowId=${storeSelectedRowId.value},hasPar=${storeSelectedRowHasParent.value})`,
+  );
+}
 
 // 每行标签条是否显示：缺省为显示，仅在为 false 时隐藏；与 collapsedActivityIds 一样持久化到设置
 const rowTagStripVisible = computed(() => settingStore.settings.activityRowTagStripVisible);
@@ -617,6 +643,7 @@ function blurTitleEditsExcept(keepActivityId: number | null) {
 
 function handleTitleInputFocus(item: Activity) {
   if (isMobile.value && !titleEditAllowed[item.id]) {
+    debugLogRowSelection("mobile-title-1st-tap(refocus-no-select-yet)", item.id);
     nextTick(() => {
       rowInputMap.value.get(item.id)?.blur();
     });
@@ -650,6 +677,9 @@ function handleTitleTouchEnd(e: TouchEvent, item: Activity) {
   blurSearchInput();
   titleEditAllowed[id] = true;
   focusTitleInput(id);
+  nextTick(() => {
+    debugLogRowSelection("mobile-title-edit-open(no-emit-focus-row)", id);
+  });
 }
 
 function handleTitleTouchCancel(_item: Activity) {
@@ -678,6 +708,9 @@ function handleFocusRow(id: number) {
   blurSearchInput();
   blurTitleEditsExcept(id);
   emit("focus-row", id);
+  nextTick(() => {
+    debugLogRowSelection("row-focus(synced)", id);
+  });
 }
 
 // PC 上首行即 return，无实际效果；savedTopHeight 在本组件内从未赋值，移动端恢复分支亦不会执行

--- a/src/components/ActivitySheet/ActivitySheet.vue
+++ b/src/components/ActivitySheet/ActivitySheet.vue
@@ -91,6 +91,13 @@ const { activityList } = storeToRefs(dataStore);
 const dateService = dataStore.dateService;
 const { isMobile } = useDevice();
 
+/** activeId 与 selectedActivityId 经 Tracker 同步后可能只存其一，业务上需统一解析 */
+const sheetPrimaryActivityId = computed(() => {
+  const a = activeId.value;
+  if (a != null && a !== undefined) return a;
+  return selectedActivityId.value;
+});
+
 // ========================
 // Emits 定义
 // ========================
@@ -225,7 +232,7 @@ function filteredBySection(section: ActivitySectionConfig) {
 
 // 活动筛选，由 section 单独管理
 function handleSectionFilter(idx: number, filterKey: string) {
-  activeId.value = null;
+  emit("update-active-id", null);
   const option = filterOptions.find((opt) => opt.key === filterKey);
   if (option) {
     sections.value[idx].filterKey = filterKey;
@@ -263,26 +270,27 @@ function showErrorPopover(message: string) {
 
 // 选择活动处理函数，提示
 function pickActivity() {
+  const id = sheetPrimaryActivityId.value;
   // 1. 检查是否有选中的活动
-  if (activeId.value == null) {
+  if (id == null || id === undefined) {
     showErrorPopover("请选择一个活动！");
     return;
   }
 
   // 2. 查找todo中是否有对应的活动
-  const relatedTodo = todoByActivityId.value.get(activeId.value);
+  const relatedTodo = todoByActivityId.value.get(id);
   if (relatedTodo && !relatedTodo.deleted) {
     showErrorPopover("【" + timestampToDatetime(relatedTodo.id) + "】启动待办");
     dateService.navigateTo(new Date(relatedTodo.id));
-    emit("update-active-id", activeId.value);
+    emit("update-active-id", id);
     return;
   }
 
-  const relatedSchedule = scheduleByActivityId.value.get(activeId.value);
+  const relatedSchedule = scheduleByActivityId.value.get(id);
   if (relatedSchedule) {
     if (relatedSchedule.activityDueRange[0]) {
       dateService.navigateTo(new Date(relatedSchedule.activityDueRange[0]));
-      emit("update-active-id", activeId.value);
+      emit("update-active-id", id);
     } else {
       showErrorPopover("预约尚未设置时间！");
     }
@@ -290,7 +298,7 @@ function pickActivity() {
     return;
   }
 
-  const picked = activityById.value.get(activeId.value);
+  const picked = activityById.value.get(id);
   if (!picked) return;
 
   // 4. 触发事件并重置选中状态
@@ -361,8 +369,9 @@ function handleFocusSearch() {
 
 // 切换番茄钟类型
 function togglePomoType() {
-  if (activeId.value !== null) {
-    emit("toggle-pomo-type", activeId.value);
+  const id = sheetPrimaryActivityId.value;
+  if (id != null && id !== undefined) {
+    emit("toggle-pomo-type", id);
   }
 }
 

--- a/src/components/TagSystem/TagManager.vue
+++ b/src/components/TagSystem/TagManager.vue
@@ -188,7 +188,7 @@ const sortKey = ref<"count" | "name">("count");
 const sortDirection = ref<"asc" | "desc">("desc");
 const currentPage = ref(1);
 
-const pageSize = computed(() => (isMobile.value ? 16 : 34));
+const pageSize = computed(() => (isMobile.value ? 18 : 34));
 // 弹窗显示：未传 show 时由外层 modal 控制，内层始终显示；传了 show 则跟随父组件
 const showModal = computed({
   get: () => (props.show === undefined ? true : !!props.show),

--- a/src/composables/useViewportDebugSnapshot.ts
+++ b/src/composables/useViewportDebugSnapshot.ts
@@ -191,7 +191,7 @@ export function formatViewportDebugReport(s: ViewportDebugSnapshot): string {
 export function useViewportDebugSnapshot() {
   const snapshot = ref<ViewportDebugSnapshot | null>(null);
 
-  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let debounceTimer: ReturnType<typeof window.setTimeout> | undefined;
 
   function refresh() {
     snapshot.value = captureViewportDebugSnapshot();

--- a/src/stores/useDataStore.ts
+++ b/src/stores/useDataStore.ts
@@ -225,8 +225,10 @@ export const useDataStore = defineStore(
 
     // ======================== 5. 派生UI状态 (Computed) ========================
     const selectedActivity = computed(() => {
-      const id = activeId.value;
-      if (id == null) return null;
+      // Tracker 同步会把看板 activeId 清掉只留 selectedActivityId，两者应都能解析当前选中活动
+      const a = activeId.value;
+      const id = a != null && a !== undefined ? a : selectedActivityId.value;
+      if (id == null || id === undefined) return null;
       return activityById.value.get(id) ?? null;
     });
 


### PR DESCRIPTION


# [S1 C1 UV1]: fix UI 识别选中状态
- **fix(ui): 状态同步失败导致无法删除**
- **chore(release): v0.6.6**

## 说明
- 用户提出bug，先修复了，并且打包了个新的版本

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core selection/derived-state logic used across the activity UI; behavior changes could affect highlighting and which item actions apply to if edge cases exist.
> 
> **Overview**
> **Fixes kanban/Planner selection desync** by treating `activeId` and `selectedActivityId` as interchangeable “current selection” when enabling actions (delete/restore, create child, toggle pomo type, pick activity) and when resolving `selectedActivity` in the data store.
> 
> Also tweaks focus/selection interactions in the activity sheet (clearing selection via `update-active-id`, dropdown opening refocuses search, adds temporary debug logs), plus small housekeeping: bump app/Tauri version to `0.6.6`, increase mobile tag manager page size, and tighten `setTimeout` typing in `useViewportDebugSnapshot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253aac81808f44a9f4cea5a856812f394f5cfc20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->