### PR TITLE
[S2 C1 UV1] Fab按钮+作废番茄改造+tagSelector输入行为+planner 切换高度一致

### DIFF
--- a/src/__tests__/chartDataService.test.ts
+++ b/src/__tests__/chartDataService.test.ts
@@ -15,7 +15,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [1, 2, 3], // 总计6个番茄
+          realPomo: [1, 1, 1, 1, 1, 1], // 扁平6个完成（新格式）
           pomoType: "🍅",
         },
         {
@@ -25,7 +25,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [2, 2], // 总计4个番茄
+          realPomo: [1, 1, 1, 1], // 扁平4个完成（新格式）
           pomoType: "🍅",
         },
       ];
@@ -55,7 +55,7 @@ describe("chartDataService", () => {
           activityTitle: "测试",
           priority: 1,
           status: "", // 未完成  ✅ 有效
-          realPomo: [1, 2],
+          realPomo: [1, 1, 1], // 扁平格式
           pomoType: "🍅",
         },
         {
@@ -75,7 +75,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [0], // 0个番茄
+          realPomo: [0, 0], // 0个完成（新格式）
           pomoType: "🍅",
         },
         {
@@ -85,7 +85,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [1], // ✅ 有效
+          realPomo: [1, 0], // ✅ 有效（新格式）
           pomoType: "🍅",
         },
       ];
@@ -106,7 +106,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [5],
+          realPomo: [1, 1, 1, 1, 1],
           pomoType: "🍅",
           deleted: true,
         },
@@ -117,7 +117,7 @@ describe("chartDataService", () => {
           priority: 1,
           status: "done",
           doneTime: 1717920000000,
-          realPomo: [2],
+          realPomo: [1, 1],
           pomoType: "🍅",
           deleted: false,
         },

--- a/src/__tests__/useDataStore.test.ts
+++ b/src/__tests__/useDataStore.test.ts
@@ -35,7 +35,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1749447475938,
-        realPomo: [1, 4], // 5个番茄
+        realPomo: [1, 1, 1, 1, 1], // 5个完成（新扁平格式）
         pomoType: "🍅",
       },
       {
@@ -45,7 +45,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1749526421608,
-        realPomo: [1], // 1个番茄
+        realPomo: [1, 0, 0], // 1个完成
         pomoType: "🍅",
       },
     ];
@@ -105,7 +105,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1717920000000, // 2024-06-09
-        realPomo: [3],
+        realPomo: [1, 1, 1],
         pomoType: "🍅",
       },
       {
@@ -115,7 +115,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1717923600000, // 2024-06-09（1小时后）
-        realPomo: [5],
+        realPomo: [1, 1, 1, 1, 1],
         pomoType: "🍅",
       },
       {
@@ -125,7 +125,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1718006400000, // 2024-06-10
-        realPomo: [2],
+        realPomo: [1, 1],
         pomoType: "🍅",
       },
     ];
@@ -149,7 +149,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1717920000000,
-        realPomo: [3],
+        realPomo: [1, 1, 1],
         pomoType: "🍅",
       },
       {
@@ -159,7 +159,7 @@ describe("useDataStore - 图表数据功能", () => {
         priority: 1,
         status: "done",
         doneTime: 1718006400000,
-        realPomo: [2],
+        realPomo: [1, 1],
         pomoType: "🍅",
       },
     ];

--- a/src/components/ActivitySheet/ActivitySheet.vue
+++ b/src/components/ActivitySheet/ActivitySheet.vue
@@ -433,7 +433,10 @@ function getCountdownClass(dueDate: number | undefined | null): string {
     height: 0px;
   }
   .kanban-columns {
-    height: calc(100% - 5px - env(safe-area-inset-bottom));
+    /* --vv-obscured-bottom：键盘打开时避免再扣一遍 safe-area 造成 iOS 底部灰条 */
+    height: calc(
+      100% - 5px - max(0px, env(safe-area-inset-bottom) - min(env(safe-area-inset-bottom), var(--vv-obscured-bottom, 0px)))
+    );
   }
 }
 </style>

--- a/src/components/DayPlanner/DaySchedule.vue
+++ b/src/components/DayPlanner/DaySchedule.vue
@@ -208,8 +208,8 @@
                 v-if="editingRowId === schedule.id && editingField === 'title'"
                 :ref="(el: any) => (titleInputRef = el)"
                 v-model="editingValue"
-                @blur="saveEdit(schedule)"
-                @keyup.enter="saveEdit(schedule)"
+                @blur="handleTitleBlur(schedule)"
+                @keyup.enter="handleTitleEnter(schedule, $event)"
                 @keyup.esc="cancelEdit"
                 @input="handleTitleInput(schedule)"
                 @keydown="handleInputKeydown($event, schedule)"
@@ -218,7 +218,7 @@
               />
               <TagPickerPopover
                 v-if="editingRowId === schedule.id && editingField === 'title'"
-                ref="tagPickerRef"
+                :ref="(el: any) => setTagPickerRef(el, schedule.id)"
                 :show="tagEditor.popoverTargetId.value === schedule.id"
                 @update:show="
                   (open: boolean) => {
@@ -229,7 +229,9 @@
                 input-mode="external"
                 placement="bottom-end"
                 :z-index="10000"
-                :popover-style="{ marginRight: '90px' }"
+                :popover-style="{ marginRight: '0px' }"
+                :panel-pointer-guard="onScheduleTagPanelPointerGuard"
+                :on-enter-before-select="onScheduleTagEnterBeforeSelect"
                 @select-tag="(tagId: any) => handleTagSelected(tagId)"
                 @create-tag="(tagName: any) => handleTagCreate(tagName)"
               >
@@ -381,6 +383,21 @@ const tagSearchTermModel = computed({
   },
 });
 const tagPickerRef = ref<InstanceType<typeof TagPickerPopover> | null>(null);
+// Enter 选中标签时置为 true，saveEdit 会跳过结束编辑以保持继续输入
+const selectingTagViaEnter = ref(false);
+// 点击/触摸标签选择器时置为 true，避免 blur 抢先触发保存导致选不中
+const isPickingTagFromSelector = ref(false);
+function onScheduleTagPanelPointerGuard() {
+  isPickingTagFromSelector.value = true;
+}
+function onScheduleTagEnterBeforeSelect() {
+  selectingTagViaEnter.value = true;
+}
+function setTagPickerRef(el: any, scheduleId: number) {
+  if (tagEditor.popoverTargetId.value === scheduleId) {
+    tagPickerRef.value = el as InstanceType<typeof TagPickerPopover> | null;
+  }
+}
 
 // 根据设备类型格式化时间显示，移动端去掉冒号
 function formatTimeForDisplay(timestamp?: number | null) {
@@ -537,9 +554,14 @@ function startEditing(scheduleId: number, field: "title" | "start" | "done" | "d
 
 function saveEdit(schedule: Schedule) {
   if (!editingRowId.value) return;
+  // Enter 选中标签后 keyup.enter 仍会触发 saveEdit，此时不结束编辑以便继续输入
+  if (selectingTagViaEnter.value) {
+    selectingTagViaEnter.value = false;
+    return;
+  }
 
   // 如果输入框中有 # 开头的文本，清理并关闭 popover
-  if (editingValue.value.includes("#") && tagEditor.popoverTargetId.value) {
+  if ((editingValue.value.includes("#") || editingValue.value.includes("@")) && tagEditor.popoverTargetId.value) {
     editingValue.value = tagEditor.clearTagTriggerText(editingValue.value);
     tagEditor.closePopover();
   }
@@ -587,7 +609,7 @@ function saveEdit(schedule: Schedule) {
 
 function cancelEdit() {
   // 如果输入框中有 # 开头的文本，清理并关闭 popover
-  if (editingValue.value.includes("#") && tagEditor.popoverTargetId.value) {
+  if ((editingValue.value.includes("#") || editingValue.value.includes("@")) && tagEditor.popoverTargetId.value) {
     editingValue.value = tagEditor.clearTagTriggerText(editingValue.value);
     tagEditor.closePopover();
   }
@@ -656,9 +678,48 @@ function handleTitleInput(schedule: Schedule) {
   tagEditor.handleContentInput(schedule.id, editingValue.value);
 }
 
-function handleInputKeydown(event: KeyboardEvent, schedule: Schedule) {
-  if (tagEditor.popoverTargetId.value === schedule.id && tagPickerRef.value) {
+function isTagPickerKeyboardActive(schedule: Schedule): boolean {
+  const popoverOpened = tagEditor.popoverTargetId.value !== null;
+  const popoverMatchCurrentRow = tagEditor.popoverTargetId.value === schedule.id;
+  const hasTriggerAtTail = /[#@][\p{L}\p{N}_]*$/u.test(editingValue.value);
+  return popoverOpened || popoverMatchCurrentRow || hasTriggerAtTail;
+}
+
+function handleTitleEnter(schedule: Schedule, event: KeyboardEvent) {
+  if (isTagPickerKeyboardActive(schedule) && tagPickerRef.value) {
+    // popover 打开时，Enter 优先选中高亮项（默认第一项），不结束编辑
+    selectingTagViaEnter.value = true;
     tagPickerRef.value.handleHostKeydown(event);
+    return;
+  }
+  saveEdit(schedule);
+}
+
+function handleTitleBlur(schedule: Schedule) {
+  if (isPickingTagFromSelector.value) {
+    isPickingTagFromSelector.value = false;
+    nextTick(() => titleInputRef.value?.focus());
+    return;
+  }
+  saveEdit(schedule);
+}
+
+function handleInputKeydown(event: KeyboardEvent, schedule: Schedule) {
+  const isTagKey = event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Enter" || event.key === "Escape";
+  const hasTriggerAtTail = /[#@][\p{L}\p{N}_]*$/u.test(editingValue.value);
+
+  // 处于 tag 输入态时，确保 popover 目标绑定到当前 schedule
+  if (hasTriggerAtTail && tagEditor.popoverTargetId.value !== schedule.id) {
+    tagEditor.popoverTargetId.value = schedule.id;
+  }
+
+  if (isTagKey && isTagPickerKeyboardActive(schedule) && tagPickerRef.value) {
+    if (event.key === "Enter") selectingTagViaEnter.value = true;
+    // 交给选择器处理，避免输入框原生行为（光标移动/提交）抢占
+    event.preventDefault();
+    event.stopPropagation();
+    tagPickerRef.value.handleHostKeydown(event);
+    return;
   }
 
   // 特殊处理：# 键自动打开 popover

--- a/src/components/DayPlanner/DaySchedule.vue
+++ b/src/components/DayPlanner/DaySchedule.vue
@@ -216,6 +216,27 @@
                 @click.stop
                 :data-schedule-id="schedule.id"
               />
+              <TagPickerPopover
+                v-if="editingRowId === schedule.id && editingField === 'title'"
+                ref="tagPickerRef"
+                :show="tagEditor.popoverTargetId.value === schedule.id"
+                @update:show="
+                  (open: boolean) => {
+                    if (!open) tagEditor.closePopover();
+                  }
+                "
+                v-model:search-term="tagSearchTermModel"
+                input-mode="external"
+                placement="bottom-end"
+                :z-index="10000"
+                :popover-style="{ marginRight: '90px' }"
+                @select-tag="(tagId: any) => handleTagSelected(tagId)"
+                @create-tag="(tagName: any) => handleTagCreate(tagName)"
+              >
+                <template #trigger>
+                  <span style="display: inline-block; width: 1px; height: 1px; pointer-events: none"></span>
+                </template>
+              </TagPickerPopover>
               <span class="ellipsis" v-else>{{ schedule.activityTitle ?? "-" }}</span>
 
               <!-- 云朵背景元素 - 只有当 isUntaetigkeit 为 true 时才显示 -->
@@ -282,22 +303,6 @@
     </template>
     {{ popoverMessage }}
   </n-popover>
-  <TagPickerPopover
-    ref="tagPickerRef"
-    :show="tagEditor.popoverTargetId.value !== null && schedulesForCurrentView.some((s) => s.id === tagEditor.popoverTargetId.value)"
-    @update:show="(open: boolean) => { if (!open) tagEditor.closePopover(); }"
-    v-model:search-term="tagSearchTermModel"
-    input-mode="external"
-    placement="bottom-start"
-    :z-index="10000"
-    :popover-style="{ marginTop: '-30px', marginLeft: '130px' }"
-    @select-tag="(tagId: any) => handleTagSelected(tagId)"
-    @create-tag="(tagName: any) => handleTagCreate(tagName)"
-  >
-    <template #trigger>
-      <span style="position: absolute; pointer-events: none"></span>
-    </template>
-  </TagPickerPopover>
 </template>
 
 <script setup lang="ts">

--- a/src/components/DayPlanner/DaySchedule.vue
+++ b/src/components/DayPlanner/DaySchedule.vue
@@ -294,7 +294,7 @@
           </tr>
         </template>
         <tr v-else class="empty-row">
-          <td colspan="7" style="text-align: center; padding: 10px">{{ isMobile ? "" : "暂无日程" }}</td>
+          <td colspan="7">{{ isMobile ? "" : "暂无日程" }}</td>
         </tr>
       </tbody>
     </table>
@@ -916,7 +916,7 @@ tr.cancel-row {
 }
 
 tr.empty-row {
-  height: 30px;
+  height: 90px;
   text-align: center;
   color: var(--color-text-secondary);
   width: 100%;

--- a/src/components/DayPlanner/DayTodo.vue
+++ b/src/components/DayPlanner/DayTodo.vue
@@ -317,24 +317,31 @@
                   <template v-for="(est, index) in todo.estPomo" :key="index">
                     <div class="pomo-group">
                       <template v-for="i in est" :key="i">
-                        <n-checkbox
-                          :size="isMobile ? 'small' : 'medium'"
-                          :class="{
-                            'pomo-cherry': todo.pomoType === '🍒',
-                            'pomo-grape': todo.pomoType === '🍇',
-                            'pomo-tomato': todo.pomoType === '🍅',
-                          }"
-                          :checked="isPomoCompleted(todo, index, i)"
-                          :disabled="todo.status === 'cancelled'"
-                          @update:checked="(checked: any) => handlePomoCheck(todo, index, i, checked)"
+                        <span
+                          class="pomo-slot-dblwrap"
+                          :class="{ 'pomo-slot-void': isPomoVoid(todo, index, i) }"
+                          v-on="pomoVoidFinger.listeners(todo, index, i)"
+                          @mousedown.capture="handlePomoSlotMouseDown(todo, index, i)"
                           @dblclick.stop="(_e: any) => handlePomoDoubleClick(todo, index, i)"
-                        />
+                        >
+                          <n-checkbox
+                            :size="isMobile ? 'small' : 'medium'"
+                            :class="{
+                              'pomo-cherry': todo.pomoType === '🍒',
+                              'pomo-grape': todo.pomoType === '🍇',
+                              'pomo-tomato': todo.pomoType === '🍅',
+                            }"
+                            :checked="isPomoCompleted(todo, index, i)"
+                            :disabled="todo.status === 'cancelled'"
+                            @update:checked="(checked: any) => handlePomoCheck(todo, index, i, checked)"
+                          />
+                        </span>
                       </template>
                       <span class="pomo-separator" v-if="todo.estPomo && index < todo.estPomo.length - 1">|</span>
                     </div>
                   </template>
                 </div>
-                <!-- 作废状态视觉提示：使用 scoped slot 或 CSS :after 显示 🥫 ，此处最小改动暂不加伪元素，保持 checkbox 原外观 -->
+                <!-- 作废态 -1：.pomo-slot-void 背景修改 -->
                 <div v-if="todo.status !== 'done' && todo.status !== 'cancelled'" class="est-buttons">
                   <!-- 删除估计按钮  -->
                   <n-button
@@ -486,7 +493,15 @@ import { useActivityTagEditor } from "@/composables/useActivityTagEditor";
 import TagPickerPopover from "../TagSystem/TagPickerPopover.vue";
 import type { SelectOption } from "naive-ui";
 import { useDevice } from "@/composables/useDevice";
-import { ensureFlatRealPomo, getRealPomoState, setPomoState, hasAnyProgress, getSlotIndexForEst } from "@/services/realPomoState";
+import { usePomoSlotVoidFingerDouble, pomoFingerVoidPathEnabled } from "@/composables/usePomoSlotVoidFingerDouble";
+import {
+  ensureFlatRealPomo,
+  getRealPomoState,
+  setPomoState,
+  hasAnyProgress,
+  getSlotIndexForEst,
+  totalSlots,
+} from "@/services/realPomoState";
 
 const dataStore = useDataStore();
 const { isMobile } = useDevice();
@@ -546,6 +561,20 @@ const popoverMessage = ref("");
 const showEstimateInput = ref(false);
 const currentTodoId = ref<number | null>(null);
 const newEstimate = ref<number>(1);
+
+/** 番茄槽位单击去抖：双击会先触发两次 update:checked，取消待处理单击后再写作废态 */
+type PomoPendingCheck = {
+  timer: number;
+  checked: boolean;
+  todoId: number;
+  estIndex: number;
+  pomoIndex: number;
+};
+const pomoPendingCheckByKey = new Map<string, PomoPendingCheck>();
+const POMO_CHECK_DEBOUNCE_MS = 220;
+// 双触/双击作废后，checkbox 仍会晚到一次 update:checked，需在窗口内忽略以免把 -1 盖回打钩
+const POMO_AFTER_DBL_SUPPRESS_CHECK_MS = POMO_CHECK_DEBOUNCE_MS + 200;
+const pomoSuppressCheckAfterDblUntil = new Map<string, number>();
 
 // Tag Editor
 const tagEditor = useActivityTagEditor();
@@ -613,6 +642,8 @@ watch(
 );
 onBeforeUnmount(() => {
   if (rankPopoverOutsideCleanup) rankPopoverOutsideCleanup();
+  for (const [, p] of pomoPendingCheckByKey) clearTimeout(p.timer);
+  pomoPendingCheckByKey.clear();
 });
 const priorityBindingDraft = reactive<Record<number, number | null>>({});
 const priorityShowInRankDraft = reactive<Record<number, boolean>>({});
@@ -912,35 +943,106 @@ function handleCheckboxChange(id: number, checked: boolean) {
 }
 
 // 番茄估计=============================
+// 双击前在 mousedown(capture) 记下槽位状态：两次 update:checked 会篡改 -1，不能仅靠 dblclick 时再读
+const pomoDblclickStartByKey = new Map<string, number>();
+
+function pomoSlotInteractionKey(todoId: number, estIndex: number, pomoIndex: number) {
+  return `${todoId}|${estIndex}|${pomoIndex}`;
+}
+
+function handlePomoSlotMouseDown(todo: Todo, estIndex: number, pomoIndex: number) {
+  if (todo.status === "cancelled") return;
+  const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
+  const st = getRealPomoState(todo, slotIndex);
+  pomoDblclickStartByKey.set(pomoSlotInteractionKey(todo.id, estIndex, pomoIndex), st);
+}
+
 // 检查番茄钟是否完成（新扁平版：使用 slotIndex 查 getRealPomoState === 1）
 function isPomoCompleted(todo: Todo, estIndex: number, pomoIndex: number): boolean {
   const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
   return getRealPomoState(todo, slotIndex) === 1;
 }
 
-// 处理番茄钟勾选（最小改动版：支持单击 0<->1 ，双击 0/1 -> -1 作废）
-function handlePomoCheck(todo: Todo, estIndex: number, pomoIndex: number, checked: boolean) {
-  // 最小改动：保留原有 checked 逻辑作为单击处理， 双击在 template @dblclick 单独处理
+function isPomoVoid(todo: Todo, estIndex: number, pomoIndex: number): boolean {
   const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
-  let newRealPomo: number[];
+  return getRealPomoState(todo, slotIndex) === -1;
+}
 
-  if (checked) {
-    newRealPomo = setPomoState(todo, slotIndex, 1);
-  } else {
-    newRealPomo = setPomoState(todo, slotIndex, 0);
+function clearPomoPendingCheckForKey(key: string) {
+  const p = pomoPendingCheckByKey.get(key);
+  if (p) {
+    clearTimeout(p.timer);
+    pomoPendingCheckByKey.delete(key);
+  }
+}
+
+// 处理番茄钟勾选：延迟提交，双击时由 handlePomoDoubleClick 清掉待处理，避免误触数据层
+function handlePomoCheck(todo: Todo, estIndex: number, pomoIndex: number, checked: boolean) {
+  const key = pomoSlotInteractionKey(todo.id, estIndex, pomoIndex);
+  const suppressUntil = pomoSuppressCheckAfterDblUntil.get(key);
+  if (suppressUntil != null) {
+    if (Date.now() < suppressUntil) return;
+    pomoSuppressCheckAfterDblUntil.delete(key);
   }
 
-  emit("update-todo-pomo", todo.id, newRealPomo);
+  clearPomoPendingCheckForKey(key);
+
+  const timer = window.setTimeout(() => {
+    pomoPendingCheckByKey.delete(key);
+    const fresh = todosForCurrentViewWithTaskRecords.value.find((t) => t.id === todo.id);
+    if (!fresh) return;
+    const slotIndex = getSlotIndexForEst(fresh, estIndex, pomoIndex);
+    const newRealPomo = setPomoState(fresh, slotIndex, checked ? 1 : 0);
+
+    emit("update-todo-pomo", todo.id, newRealPomo);
+  }, POMO_CHECK_DEBOUNCE_MS);
+
+  pomoPendingCheckByKey.set(key, { timer, checked, todoId: todo.id, estIndex, pomoIndex });
 }
 
-// 双击处理作废状态（-1 罐头 🥫）
+// 双击处理作废状态（-1 罐头）；目标态由 mousedown 时状态决定，避免两次 click 把 -1 洗成 0 后误判为「从 0 双击」
 function handlePomoDoubleClick(todo: Todo, estIndex: number, pomoIndex: number) {
-  const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
-  const currentState = getRealPomoState(todo, slotIndex);
-  const targetState = currentState === -1 ? 0 : -1; // -1 <-> 0
-  const newRealPomo = setPomoState(todo, slotIndex, targetState as 0 | 1 | -1);
-  emit("update-todo-pomo", todo.id, newRealPomo);
+  const todoId = todo.id;
+  const key = pomoSlotInteractionKey(todoId, estIndex, pomoIndex);
+  clearPomoPendingCheckForKey(key);
+  pomoSuppressCheckAfterDblUntil.set(key, Date.now() + POMO_AFTER_DBL_SUPPRESS_CHECK_MS);
+
+  const gestureStart = pomoDblclickStartByKey.has(key)
+    ? pomoDblclickStartByKey.get(key)!
+    : getRealPomoState(todo, getSlotIndexForEst(todo, estIndex, pomoIndex));
+  pomoDblclickStartByKey.delete(key);
+
+  const targetState: 0 | 1 | -1 = gestureStart === -1 ? 0 : -1;
+
+  nextTick(() => {
+    const fresh = todosForCurrentViewWithTaskRecords.value.find((t) => t.id === todoId);
+    if (!fresh) return;
+    const slotIndex = getSlotIndexForEst(fresh, estIndex, pomoIndex);
+    const newRealPomo = setPomoState(fresh, slotIndex, targetState);
+
+    emit("update-todo-pomo", todoId, newRealPomo);
+  });
 }
+
+// 手指双触作废：逻辑集中在 usePomoSlotVoidFingerDouble（Touch+Pointer 去重、capture、coarse 指针）
+const pomoVoidFinger = usePomoSlotVoidFingerDouble({
+  isEnabled: () => pomoFingerVoidPathEnabled(isMobile.value),
+  makeKey: pomoSlotInteractionKey,
+  onRecordGestureStart(todoId, estIndex, pomoIndex) {
+    const t = todosForCurrentViewWithTaskRecords.value.find((x) => x.id === todoId);
+    if (t) handlePomoSlotMouseDown(t, estIndex, pomoIndex);
+  },
+  onDoubleByKey(key: string) {
+    const parts = key.split("|");
+    if (parts.length !== 3) return;
+    const todoId = Number(parts[0]);
+    const estIndex = Number(parts[1]);
+    const pomoIndex = Number(parts[2]);
+    if (!Number.isFinite(todoId) || !Number.isFinite(estIndex) || !Number.isFinite(pomoIndex)) return;
+    const t = todosForCurrentViewWithTaskRecords.value.find((x) => x.id === todoId);
+    if (t) handlePomoDoubleClick(t, estIndex, pomoIndex);
+  },
+});
 
 // 处理新增估计（最小改动：新增段时 realPomo 末尾补0）
 function handleAddEstimate(todo: Todo) {
@@ -959,14 +1061,16 @@ function confirmAddEstimate() {
   // 确保 estPomo 数组存在
   if (!todo.estPomo) todo.estPomo = [];
 
-  // 添加新的估计值
+  // 必须先展平再 push：push 后会出现 realLen===estLen<totalSlots，ensureFlatRealPomo 会误判为 legacy，把扁平 [1,1] 当成两段完成数展开，勾选被洗乱
+  const flatBefore = ensureFlatRealPomo(todo);
   todo.estPomo.push(newEstimate.value);
 
-  // 新增段：在 realPomo 末尾补对应数量的 0（最小改动）
-  const currentFlat = ensureFlatRealPomo(todo);
-  const addedSlots = newEstimate.value;
-  for (let k = 0; k < addedSlots; k++) {
-    currentFlat.push(0);
+  const slots = totalSlots(todo);
+  const currentFlat = [...flatBefore];
+  if (currentFlat.length > slots) {
+    currentFlat.length = slots;
+  } else {
+    while (currentFlat.length < slots) currentFlat.push(0);
   }
 
   // 通知父组件更新（est 和 real 同时更新以保持一致）
@@ -1840,6 +1944,9 @@ td.col-intent .ellipsis {
 }
 
 .pomo-groups {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
   padding-right: 1px;
   z-index: 10;
 }
@@ -1849,6 +1956,22 @@ td.col-intent .ellipsis {
   align-items: center;
   flex-shrink: 0;
   gap: 0.5px;
+}
+
+.pomo-slot-dblwrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+.pomo-slot-void :deep(.n-checkbox-box) {
+  background-color: var(--color-background-dark);
+}
+
+.pomo-slot-void :deep(.n-checkbox-box__border) {
+  border-color: var(--color-text-secondary);
 }
 
 .pomo-separator {
@@ -1885,6 +2008,8 @@ td.col-intent .ellipsis {
 
 .est-buttons {
   display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .button-left {

--- a/src/components/DayPlanner/DayTodo.vue
+++ b/src/components/DayPlanner/DayTodo.vue
@@ -276,7 +276,7 @@
                 :ref="(el: any) => (titleInputRef = el)"
                 v-model="editingValue"
                 @blur="handleTitleBlur(todo)"
-                @keyup.enter="saveEdit(todo)"
+                @keyup.enter="handleTitleEnter(todo, $event)"
                 @keyup.esc="cancelEdit"
                 @input="handleTitleInput(todo)"
                 @keydown="handleInputKeydown($event, todo)"
@@ -285,7 +285,7 @@
               />
               <TagPickerPopover
                 v-if="editingRowId === todo.id && editingField === 'title'"
-                ref="tagPickerRef"
+                :ref="(el: any) => setTagPickerRef(el, todo.id)"
                 :show="tagEditor.popoverTargetId.value === todo.id"
                 @update:show="
                   (open: boolean) => {
@@ -295,7 +295,7 @@
                 v-model:search-term="tagSearchTermModel"
                 input-mode="external"
                 placement="bottom-end"
-                :popover-style="{ marginRight: '90px' }"
+                :popover-style="{ marginRight: '0px' }"
                 :z-index="10000"
                 :panel-pointer-guard="onTodoTagPanelPointerGuard"
                 :on-enter-before-select="onTodoTagEnterBeforeSelect"
@@ -585,6 +585,11 @@ const tagSearchTermModel = computed({
   },
 });
 const tagPickerRef = ref<InstanceType<typeof TagPickerPopover> | null>(null);
+function setTagPickerRef(el: any, todoId: number) {
+  if (tagEditor.popoverTargetId.value === todoId) {
+    tagPickerRef.value = el as InstanceType<typeof TagPickerPopover> | null;
+  }
+}
 // Enter 选中标签时置为 true，saveEdit 会跳过结束编辑以保持继续输入
 const selectingTagViaEnter = ref(false);
 // 点击/触摸标签选择器时置为 true，避免移动端 blur 抢先触发保存导致选不中
@@ -1532,9 +1537,39 @@ function handleTitleInput(todo: Todo) {
   tagEditor.handleContentInput(todo.id, editingValue.value);
 }
 
-function handleInputKeydown(event: KeyboardEvent, todo: Todo) {
-  if (tagEditor.popoverTargetId.value === todo.id && tagPickerRef.value) {
+function isTagPickerKeyboardActive(todo: Todo): boolean {
+  const popoverOpened = tagEditor.popoverTargetId.value !== null;
+  const popoverMatchCurrentTodo = tagEditor.popoverTargetId.value === todo.id;
+  const hasTriggerAtTail = /[#@][\p{L}\p{N}_]*$/u.test(editingValue.value);
+  return popoverOpened || popoverMatchCurrentTodo || hasTriggerAtTail;
+}
+
+function handleTitleEnter(todo: Todo, event: KeyboardEvent) {
+  if (isTagPickerKeyboardActive(todo) && tagPickerRef.value) {
+    // popover 打开时，Enter 优先选中高亮项（默认第一项），不结束编辑
+    selectingTagViaEnter.value = true;
     tagPickerRef.value.handleHostKeydown(event);
+    return;
+  }
+  saveEdit(todo);
+}
+
+function handleInputKeydown(event: KeyboardEvent, todo: Todo) {
+  const isTagKey = event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Enter" || event.key === "Escape";
+  const hasTriggerAtTail = /[#@][\p{L}\p{N}_]*$/u.test(editingValue.value);
+
+  // 处于 tag 输入态时，确保 popover 目标绑定到当前 todo
+  if (hasTriggerAtTail && tagEditor.popoverTargetId.value !== todo.id) {
+    tagEditor.popoverTargetId.value = todo.id;
+  }
+
+  if (isTagKey && isTagPickerKeyboardActive(todo) && tagPickerRef.value) {
+    if (event.key === "Enter") selectingTagViaEnter.value = true;
+    // 交给选择器处理，避免输入框原生行为（光标移动/提交）抢占
+    event.preventDefault();
+    event.stopPropagation();
+    tagPickerRef.value.handleHostKeydown(event);
+    return;
   }
 
   // 特殊处理：# 键自动打开 popover

--- a/src/components/DayPlanner/DayTodo.vue
+++ b/src/components/DayPlanner/DayTodo.vue
@@ -105,7 +105,11 @@
             <n-button
               class="cancel-button"
               v-if="
-                selectedTodo && selectedTodo.status !== 'done' && selectedTodo.status !== 'cancelled' && !selectedTodo.realPomo && !isMobile
+                selectedTodo &&
+                selectedTodo.status !== 'done' &&
+                selectedTodo.status !== 'cancelled' &&
+                !hasAnyProgress(selectedTodo) &&
+                !isMobile
               "
               text
               @click.stop="handleCancelSelectedTodo"
@@ -123,7 +127,7 @@
                 selectedTodo &&
                 selectedTodo.status !== 'done' &&
                 selectedTodo.status !== 'cancelled' &&
-                !selectedTodo.realPomo &&
+                !hasAnyProgress(selectedTodo) &&
                 !selectedTodo.startTime &&
                 !isMobile
               "
@@ -323,12 +327,14 @@
                           :checked="isPomoCompleted(todo, index, i)"
                           :disabled="todo.status === 'cancelled'"
                           @update:checked="(checked: any) => handlePomoCheck(todo, index, i, checked)"
+                          @dblclick.stop="(_e: any) => handlePomoDoubleClick(todo, index, i)"
                         />
                       </template>
                       <span class="pomo-separator" v-if="todo.estPomo && index < todo.estPomo.length - 1">|</span>
                     </div>
                   </template>
                 </div>
+                <!-- 作废状态视觉提示：使用 scoped slot 或 CSS :after 显示 🥫 ，此处最小改动暂不加伪元素，保持 checkbox 原外观 -->
                 <div v-if="todo.status !== 'done' && todo.status !== 'cancelled'" class="est-buttons">
                   <!-- 删除估计按钮  -->
                   <n-button
@@ -480,6 +486,7 @@ import { useActivityTagEditor } from "@/composables/useActivityTagEditor";
 import TagPickerPopover from "../TagSystem/TagPickerPopover.vue";
 import type { SelectOption } from "naive-ui";
 import { useDevice } from "@/composables/useDevice";
+import { ensureFlatRealPomo, getRealPomoState, setPomoState, hasAnyProgress, getSlotIndexForEst } from "@/services/realPomoState";
 
 const dataStore = useDataStore();
 const { isMobile } = useDevice();
@@ -905,32 +912,37 @@ function handleCheckboxChange(id: number, checked: boolean) {
 }
 
 // 番茄估计=============================
-// 检查番茄钟是否完成
+// 检查番茄钟是否完成（新扁平版：使用 slotIndex 查 getRealPomoState === 1）
 function isPomoCompleted(todo: Todo, estIndex: number, pomoIndex: number): boolean {
-  if (!todo.realPomo || todo.realPomo.length <= estIndex) return false;
-  return todo.realPomo[estIndex] >= pomoIndex;
+  const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
+  return getRealPomoState(todo, slotIndex) === 1;
 }
 
-// 处理番茄钟勾选
+// 处理番茄钟勾选（最小改动版：支持单击 0<->1 ，双击 0/1 -> -1 作废）
 function handlePomoCheck(todo: Todo, estIndex: number, pomoIndex: number, checked: boolean) {
-  // 确保 realPomo 数组存在且长度与 estPomo 一致
-  if (!todo.realPomo) todo.realPomo = [];
-  if (!todo.estPomo) todo.estPomo = [];
-  while (todo.realPomo.length < todo.estPomo.length) {
-    todo.realPomo.push(0);
-  }
+  // 最小改动：保留原有 checked 逻辑作为单击处理， 双击在 template @dblclick 单独处理
+  const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
+  let newRealPomo: number[];
 
   if (checked) {
-    todo.realPomo[estIndex] = Math.max(todo.realPomo[estIndex], pomoIndex);
+    newRealPomo = setPomoState(todo, slotIndex, 1);
   } else {
-    todo.realPomo[estIndex] = Math.min(todo.realPomo[estIndex], pomoIndex - 1);
+    newRealPomo = setPomoState(todo, slotIndex, 0);
   }
 
-  // 通知父组件更新
-  emit("update-todo-pomo", todo.id, todo.realPomo);
+  emit("update-todo-pomo", todo.id, newRealPomo);
 }
 
-// 处理新增估计
+// 双击处理作废状态（-1 罐头 🥫）
+function handlePomoDoubleClick(todo: Todo, estIndex: number, pomoIndex: number) {
+  const slotIndex = getSlotIndexForEst(todo, estIndex, pomoIndex);
+  const currentState = getRealPomoState(todo, slotIndex);
+  const targetState = currentState === -1 ? 0 : -1; // -1 <-> 0
+  const newRealPomo = setPomoState(todo, slotIndex, targetState as 0 | 1 | -1);
+  emit("update-todo-pomo", todo.id, newRealPomo);
+}
+
+// 处理新增估计（最小改动：新增段时 realPomo 末尾补0）
 function handleAddEstimate(todo: Todo) {
   currentTodoId.value = todo.id;
   newEstimate.value = 1;
@@ -950,8 +962,16 @@ function confirmAddEstimate() {
   // 添加新的估计值
   todo.estPomo.push(newEstimate.value);
 
-  // 通知父组件更新
+  // 新增段：在 realPomo 末尾补对应数量的 0（最小改动）
+  const currentFlat = ensureFlatRealPomo(todo);
+  const addedSlots = newEstimate.value;
+  for (let k = 0; k < addedSlots; k++) {
+    currentFlat.push(0);
+  }
+
+  // 通知父组件更新（est 和 real 同时更新以保持一致）
   emit("update-todo-est", todo.id, todo.estPomo);
+  emit("update-todo-pomo", todo.id, currentFlat);
 
   // 重置状态并关闭对话框
   showEstimateInput.value = false;
@@ -966,31 +986,34 @@ function cancelAddEstimate() {
   newEstimate.value = 1; // 重置为默认值
 }
 
-// 删除估计
+// 删除估计（最小改动：使用 ensureFlatRealPomo 检查最后一段是否有非0状态）
 function handleDeleteEstimate(todo: Todo) {
-  if (todo.estPomo && todo.estPomo.length > 0) {
-    // 要删除的下标是最后一项
-    const delIdx = todo.estPomo.length - 1;
-    if (todo.realPomo && delIdx < todo.realPomo.length && todo.realPomo[delIdx] !== undefined && todo.realPomo[delIdx] !== 0) {
-      // realPomo此位置已被填写，提示不能删
-      popoverMessage.value = "已经有实际完成，不可删除~";
-      showPopover.value = true;
-      setTimeout(() => {
-        showPopover.value = false;
-      }, 2000);
-      return;
-    }
-    // 可以删
-    todo.estPomo.pop();
-    emit("update-todo-est", todo.id, todo.estPomo);
-  } else {
+  if (!todo.estPomo || todo.estPomo.length === 0) {
     popoverMessage.value = "没啦，别删了~";
     showPopover.value = true;
-    setTimeout(() => {
-      showPopover.value = false;
-    }, 2000);
+    setTimeout(() => (showPopover.value = false), 2000);
     return;
   }
+
+  const delIdx = todo.estPomo.length - 1;
+  const flat = ensureFlatRealPomo(todo);
+  const startSlot = getSlotIndexForEst(todo, delIdx, 1); // 该段起始 slot
+  const segLength = typeof todo.estPomo[delIdx] === "number" ? todo.estPomo[delIdx]! : 0;
+  const segSlice = flat.slice(startSlot, startSlot + segLength);
+  const hasProgressInSeg = segSlice.some((v) => v !== 0); // 1 or -1 都算有进度
+
+  if (hasProgressInSeg) {
+    popoverMessage.value = "该段已有完成或作废，不可删除~";
+    showPopover.value = true;
+    setTimeout(() => (showPopover.value = false), 2000);
+    return;
+  }
+
+  // 可以删：弹出 estPomo 最后一段，realPomo 尾部对应槽位也截断（写路径确保扁平）
+  todo.estPomo.pop();
+  const newReal = flat.slice(0, startSlot);
+  emit("update-todo-est", todo.id, todo.estPomo);
+  emit("update-todo-pomo", todo.id, newReal); // 同时更新 realPomo 长度
 }
 
 // 修改点击行处理函数
@@ -1241,7 +1264,7 @@ function handleSuspendSelectedTodo() {
     !selectedTodo.value ||
     selectedTodo.value.status === "done" ||
     selectedTodo.value.status === "cancelled" ||
-    selectedTodo.value.realPomo
+    hasAnyProgress(selectedTodo.value) // 新逻辑：有任意进度（1或-1）视为已开始，不能 suspend
   )
     return;
   emit("suspend-todo", selectedTodo.value.id);
@@ -1253,7 +1276,7 @@ function handleCancelSelectedTodo() {
     !selectedTodo.value ||
     selectedTodo.value.status === "done" ||
     selectedTodo.value.status === "cancelled" ||
-    selectedTodo.value.realPomo
+    hasAnyProgress(selectedTodo.value) // 新逻辑：有任意进度视为已开始，不能 cancel
   )
     return;
   emit("cancel-todo", selectedTodo.value.id);

--- a/src/components/DayPlanner/DayTodo.vue
+++ b/src/components/DayPlanner/DayTodo.vue
@@ -279,7 +279,30 @@
                 @click.stop
                 :data-todo-id="todo.id"
               />
-              <span class="ellipsis" v-else>{{ todo.activityTitle ?? "-" }}</span>
+              <TagPickerPopover
+                v-if="editingRowId === todo.id && editingField === 'title'"
+                ref="tagPickerRef"
+                :show="tagEditor.popoverTargetId.value === todo.id"
+                @update:show="
+                  (open: boolean) => {
+                    if (!open) tagEditor.closePopover();
+                  }
+                "
+                v-model:search-term="tagSearchTermModel"
+                input-mode="external"
+                placement="bottom-end"
+                :popover-style="{ marginRight: '90px' }"
+                :z-index="10000"
+                :panel-pointer-guard="onTodoTagPanelPointerGuard"
+                :on-enter-before-select="onTodoTagEnterBeforeSelect"
+                @select-tag="(tagId: any) => handleTagSelected(tagId)"
+                @create-tag="(tagName: any) => handleTagCreate(tagName)"
+              >
+                <template #trigger>
+                  <span style="display: inline-block; width: 1px; height: 1px; pointer-events: none"></span>
+                </template>
+              </TagPickerPopover>
+              <span class="ellipsis" v-if="!(editingRowId === todo.id && editingField === 'title')">{{ todo.activityTitle ?? "-" }}</span>
             </td>
 
             <!-- 6 果果 -->
@@ -384,32 +407,6 @@
   >
     <n-input-number v-model:value="newEstimate" :min="1" :max="5" placeholder="请输入估计的番茄数" style="width: 100%" />
   </n-modal>
-  <!-- Tag Selector Popover -->
-  <TagPickerPopover
-    ref="tagPickerRef"
-    :show="
-      tagEditor.popoverTargetId.value !== null && todosForCurrentViewWithTaskRecords.some((t) => t.id === tagEditor.popoverTargetId.value)
-    "
-    @update:show="
-      (open: boolean) => {
-        if (!open) tagEditor.closePopover();
-      }
-    "
-    v-model:search-term="tagSearchTermModel"
-    input-mode="external"
-    placement="bottom-start"
-    :z-index="10000"
-    :popover-style="{ marginTop: '-30px', marginLeft: '130px' }"
-    :panel-pointer-guard="onTodoTagPanelPointerGuard"
-    :on-enter-before-select="onTodoTagEnterBeforeSelect"
-    @select-tag="(tagId: any) => handleTagSelected(tagId)"
-    @create-tag="(tagName: any) => handleTagCreate(tagName)"
-  >
-    <template #trigger>
-      <span style="position: absolute; pointer-events: none"></span>
-    </template>
-  </TagPickerPopover>
-
   <!-- 排序槽位绑定 tag：单击表头「排序」打开，失去焦点自动保存 -->
   <n-modal
     v-model:show="showPriorityBindingModal"

--- a/src/components/DayPlanner/DayTodo.vue
+++ b/src/components/DayPlanner/DayTodo.vue
@@ -395,7 +395,7 @@
           </tr>
         </template>
         <tr v-else class="empty-row">
-          <td colspan="7" style="text-align: center; padding: 10px">{{ isMobile ? "" : "暂无待办" }}</td>
+          <td colspan="7">{{ isMobile ? "" : "暂无待办" }}</td>
         </tr>
       </tbody>
     </table>

--- a/src/components/MobileHomeFab/MobileHomeFab.vue
+++ b/src/components/MobileHomeFab/MobileHomeFab.vue
@@ -99,14 +99,14 @@
             </n-button>
             <template v-if="showActivityPanel">
               <n-button
-                v-if="!hasParent"
+                v-if="!hasParent && !selectedRowHasParent"
                 secondary
                 circle
                 type="default"
                 size="large"
                 title="生成子活动"
                 :disabled="isSelectedRowDone || isSelectedClassS || isDeleted || noSelectedActivity"
-                @click="emit('create-child-activity', activeId ?? selectedActivityId ?? null)"
+                @click="emit('create-child-activity', effectiveActivityId ?? null)"
               >
                 <template #icon>
                   <n-icon><TextGrammarArrowRight24Regular /></n-icon>
@@ -120,7 +120,7 @@
                 size="large"
                 title="升级为兄弟"
                 :disabled="effectiveActivityId == null || isSelectedClassS"
-                @click="emit('increase-child-activity', activeId ?? selectedActivityId ?? null)"
+                @click="emit('increase-child-activity', effectiveActivityId ?? null)"
               >
                 <template #icon>
                   <n-icon><TextGrammarArrowLeft24Regular /></n-icon>
@@ -129,7 +129,7 @@
             </template>
             <n-button
               :title="isDeleted && effectiveActivityId != null ? '恢复活动' : '删除活动'"
-              @click="emit('delete-activity', activeId ?? selectedActivityId ?? null)"
+              @click="emit('delete-activity', effectiveActivityId ?? null)"
               circle
               secondary
               :type="isDeleted ? 'error' : 'default'"
@@ -220,8 +220,17 @@ const { taskRecordEditing } = toRefs(props);
 const settingStore = useSettingStore();
 
 const dataStore = useDataStore();
-const { activeId, selectedActivityId, selectedRowId, isSelectedRowDone, selectedActivity } = storeToRefs(dataStore);
-const { activityById, todoByActivityId, scheduleByActivityId } = storeToRefs(dataStore);
+const {
+  activeId,
+  selectedActivityId,
+  selectedRowId,
+  isSelectedRowDone,
+  selectedActivity,
+  selectedRowHasParent,
+  activityById,
+  todoByActivityId,
+  scheduleByActivityId,
+} = storeToRefs(dataStore);
 const dateService = dataStore.dateService;
 
 const isDeleted = computed(() => selectedActivity.value?.deleted ?? false);
@@ -238,8 +247,7 @@ const effectiveActivityId = computed(() => {
 /** 与 ActivitySheet 一致：无选中且非今日 →「回到当下」 */
 const showBackToToday = computed(() => !dateService.isViewDateToday);
 const showRowActions = computed(
-  () =>
-    selectedRowId.value != null || (activeId.value != null && activeId.value !== undefined) || selectedActivityId.value != null,
+  () => selectedRowId.value != null || activeId.value != null || selectedActivityId.value != null,
 );
 const showUpPopover = computed(() => showBackToToday.value || showRowActions.value);
 const showActivityPanel = computed(() => settingStore.settings.showActivity);

--- a/src/components/MobileHomeFab/MobileHomeFab.vue
+++ b/src/components/MobileHomeFab/MobileHomeFab.vue
@@ -335,7 +335,8 @@ onUnmounted(() => {
 .mobile-home-fab {
   position: fixed;
   right: 15px;
-  bottom: max(30px, env(safe-area-inset-bottom));
+  /* --vv-fab-lift：Home 根节点根据 visualViewport 注入，软键盘抬起时上移 */
+  bottom: calc(max(30px, env(safe-area-inset-bottom)) + var(--vv-fab-lift, 0px));
   z-index: 90;
   pointer-events: auto;
 }

--- a/src/components/MobileHomeFab/MobileHomeFab.vue
+++ b/src/components/MobileHomeFab/MobileHomeFab.vue
@@ -86,7 +86,7 @@
             <n-button
               v-if="showActivityPanel"
               @click="handlePickActivity"
-              :disabled="activeId == null || isDeleted || isSelectedRowDone"
+              :disabled="effectiveActivityId == null || isDeleted || isSelectedRowDone"
               circle
               secondary
               type="default"
@@ -119,7 +119,7 @@
                 circle
                 size="large"
                 title="升级为兄弟"
-                :disabled="activeId === null || isSelectedClassS"
+                :disabled="effectiveActivityId == null || isSelectedClassS"
                 @click="emit('increase-child-activity', activeId ?? selectedActivityId ?? null)"
               >
                 <template #icon>
@@ -128,7 +128,7 @@
               </n-button>
             </template>
             <n-button
-              :title="isDeleted && activeId !== null && activeId !== undefined ? '恢复活动' : '删除活动'"
+              :title="isDeleted && effectiveActivityId != null ? '恢复活动' : '删除活动'"
               @click="emit('delete-activity', activeId ?? selectedActivityId ?? null)"
               circle
               secondary
@@ -138,7 +138,7 @@
             >
               <template #icon>
                 <n-icon>
-                  <DeleteDismiss24Regular v-if="isDeleted && activeId !== null" />
+                  <DeleteDismiss24Regular v-if="isDeleted && effectiveActivityId != null" />
                   <Delete24Regular v-else />
                 </n-icon>
               </template>
@@ -228,17 +228,29 @@ const isDeleted = computed(() => selectedActivity.value?.deleted ?? false);
 const isSelectedClassS = computed(() => selectedActivity.value?.class === "S");
 const hasParent = computed(() => selectedActivity.value?.parentId ?? null);
 
+/** 看板 activeId 与 Tracker 同步后的 selectedActivityId 择一有效（与 ActivityButtons 一致） */
+const effectiveActivityId = computed(() => {
+  const a = activeId.value;
+  if (a != null && a !== undefined) return a;
+  return selectedActivityId.value;
+});
+
 /** 与 ActivitySheet 一致：无选中且非今日 →「回到当下」 */
 const showBackToToday = computed(() => !dateService.isViewDateToday);
-const showRowActions = computed(() => selectedRowId.value !== null || activeId.value !== null);
+const showRowActions = computed(
+  () =>
+    selectedRowId.value != null || (activeId.value != null && activeId.value !== undefined) || selectedActivityId.value != null,
+);
 const showUpPopover = computed(() => showBackToToday.value || showRowActions.value);
 const showActivityPanel = computed(() => settingStore.settings.showActivity);
-const noSelectedActivity = computed(() => selectedRowId.value == null && selectedActivityId.value == null);
+const noSelectedActivity = computed(
+  () => selectedRowId.value == null && selectedActivityId.value == null && activeId.value == null,
+);
 
 /** 与 ActivitySheet.pickActivity 一致 */
 function handlePickActivity() {
-  const aid = activeId.value;
-  if (aid == null) {
+  const aid = effectiveActivityId.value;
+  if (aid == null || aid === undefined) {
     emit("notify", "请选择一个活动！");
     return;
   }

--- a/src/components/MonthPlanner/MonthPlanner.vue
+++ b/src/components/MonthPlanner/MonthPlanner.vue
@@ -76,6 +76,7 @@ import { storeToRefs } from "pinia";
 import { useDevice } from "@/composables/useDevice";
 import { createTouchScheduledSingleAndDouble } from "@/composables/useTouchScheduledSingleAndDouble";
 import { useSettingStore } from "@/stores/useSettingStore";
+import { countCompletedPomos } from "@/services/realPomoState";
 
 const settingStore = useSettingStore();
 const isTaskVisible = computed(() => settingStore.settings.showTask);
@@ -230,12 +231,7 @@ const days = computed(() => {
     const sumRealPomo = bucket
       .filter((i) => i.type === "todo" && i.pomoType === "🍅")
       .reduce((sum, item) => {
-        // 临时兼容：如果有 countCompletedPomos 则优先使用，否则回退旧逻辑
-        const completed = typeof (item as any).realPomo !== "undefined" ? 
-          // 由于 MonthPlanner 传入的是 plain object，暂时保持旧 reduce（后续可引入 realPomoState）
-          (Array.isArray((item as any).realPomo) ? (item as any).realPomo.reduce((s: number, n: number) => s + (Number(n) || 0), 0) : 0) 
-          : 0;
-        return sum + completed;
+        return sum + countCompletedPomos(item as Todo);
       }, 0);
 
     const sumRealGrape = bucket

--- a/src/components/MonthPlanner/MonthPlanner.vue
+++ b/src/components/MonthPlanner/MonthPlanner.vue
@@ -226,14 +226,16 @@ const days = computed(() => {
 
     const sorted = [...schedules.slice().sort((a, b) => a.ts - b.ts), ...prioritizedTodos, ...otherTodos];
 
-    // 聚合当日 realPomo
+    // 聚合当日 realPomo - 使用 countCompletedPomos 统一统计（支持 -1 作废）
     const sumRealPomo = bucket
       .filter((i) => i.type === "todo" && i.pomoType === "🍅")
       .reduce((sum, item) => {
-        const arr = item.realPomo;
-        if (!Array.isArray(arr) || arr.length === 0) return sum;
-        const itemSum = arr.reduce((s, n) => s + (Number(n) || 0), 0);
-        return sum + itemSum;
+        // 临时兼容：如果有 countCompletedPomos 则优先使用，否则回退旧逻辑
+        const completed = typeof (item as any).realPomo !== "undefined" ? 
+          // 由于 MonthPlanner 传入的是 plain object，暂时保持旧 reduce（后续可引入 realPomoState）
+          (Array.isArray((item as any).realPomo) ? (item as any).realPomo.reduce((s: number, n: number) => s + (Number(n) || 0), 0) : 0) 
+          : 0;
+        return sum + completed;
       }, 0);
 
     const sumRealGrape = bucket

--- a/src/components/PomotentionTimer/PomodoroSequence.vue
+++ b/src/components/PomotentionTimer/PomodoroSequence.vue
@@ -678,6 +678,11 @@ function resetWhiteNoise(sound: SoundType) {
   height: 100%;
 }
 
+:deep(.n-input.n-input--textarea.n-input--resizable .n-input-wrapper) {
+  resize: none !important;
+  min-height: 25px !important;
+}
+
 .hint-text {
   font-size: 12px;
   color: gray;

--- a/src/components/TagSystem/TagPickerPopover.vue
+++ b/src/components/TagSystem/TagPickerPopover.vue
@@ -19,7 +19,7 @@
       class="tag-picker-panel"
       @pointerdown="onPanelPointerInteraction"
       @mousedown="onPanelPointerInteraction"
-      @touchstart="onPanelPointerInteraction"
+      @touchstart.passive="onPanelPointerInteraction"
     >
       <!-- 内置搜索：Home 筛选等；#/@ 场景用 external，搜索由宿主输入同步 -->
       <n-input

--- a/src/composables/usePomoSlotVoidFingerDouble.ts
+++ b/src/composables/usePomoSlotVoidFingerDouble.ts
@@ -1,0 +1,86 @@
+/**
+ * 番茄槽位：手指双触 ≈ 桌面 dblclick 作废。合并 Touch + Pointer、去重同一次抬指的重复事件；启用条件含 coarse 指针以覆盖 Android 上 isMobile 为 false 的情况。
+ */
+import { createTouchScheduledSingleAndDouble } from "@/composables/useTouchScheduledSingleAndDouble";
+
+// 同一次抬指在部分浏览器会先后触发 touchend 与 pointerup，只计一次
+const DEDUPE_MS = 70;
+
+export type PomoVoidFingerDoubleOptions = {
+  /** 是否启用手指双触（纯鼠标桌面须为 false） */
+  isEnabled: () => boolean;
+  makeKey: (todoId: number, estIndex: number, pomoIndex: number) => string;
+  onRecordGestureStart: (todoId: number, estIndex: number, pomoIndex: number) => void;
+  onDoubleByKey: (key: string) => void;
+};
+
+export function usePomoSlotVoidFingerDouble(opts: PomoVoidFingerDoubleOptions) {
+  const sched = createTouchScheduledSingleAndDouble<string>(() => {}, opts.onDoubleByKey);
+
+  let lastDown: { t: number; key: string } = { t: -1e9, key: "" };
+  let lastUp: { t: number; key: string } = { t: -1e9, key: "" };
+
+  function dedupeDown(key: string, now: number): boolean {
+    if (key === lastDown.key && now - lastDown.t < DEDUPE_MS) return true;
+    lastDown = { t: now, key };
+    return false;
+  }
+
+  function dedupeUp(key: string, now: number): boolean {
+    if (key === lastUp.key && now - lastUp.t < DEDUPE_MS) return true;
+    lastUp = { t: now, key };
+    return false;
+  }
+
+  function listeners(todo: { id: number }, estIndex: number, pomoIndex: number) {
+    const key = () => opts.makeKey(todo.id, estIndex, pomoIndex);
+
+    return {
+      onTouchstartCapture: () => {
+        if (!opts.isEnabled()) return;
+        const k = key();
+        const now = performance.now();
+        if (dedupeDown(k, now)) return;
+        opts.onRecordGestureStart(todo.id, estIndex, pomoIndex);
+      },
+      onPointerdownCapture: (e: PointerEvent) => {
+        if (!opts.isEnabled() || e.pointerType !== "touch") return;
+        const k = key();
+        const now = performance.now();
+        if (dedupeDown(k, now)) return;
+        opts.onRecordGestureStart(todo.id, estIndex, pomoIndex);
+      },
+      onTouchendCapture: () => {
+        if (!opts.isEnabled()) return;
+        const k = key();
+        const now = performance.now();
+        if (dedupeUp(k, now)) return;
+        sched.touchEnd(k);
+      },
+      onPointerupCapture: (e: PointerEvent) => {
+        if (!opts.isEnabled() || e.pointerType !== "touch") return;
+        const k = key();
+        const now = performance.now();
+        if (dedupeUp(k, now)) return;
+        sched.touchEnd(k);
+      },
+      onTouchcancelCapture: () => {
+        if (!opts.isEnabled()) return;
+        sched.touchCancel();
+      },
+      onPointercancelCapture: (e: PointerEvent) => {
+        if (!opts.isEnabled() || e.pointerType !== "touch") return;
+        sched.touchCancel();
+      },
+    };
+  }
+
+  return { listeners };
+}
+
+/** 与 DayTodo / useDevice 配合：手机或主输入为粗指针（典型 Android / 平板） */
+export function pomoFingerVoidPathEnabled(isMobile: boolean): boolean {
+  if (typeof window === "undefined") return false;
+  if (isMobile) return true;
+  return window.matchMedia?.("(pointer: coarse)")?.matches ?? false;
+}

--- a/src/composables/useTouchScheduledSingleAndDouble.ts
+++ b/src/composables/useTouchScheduledSingleAndDouble.ts
@@ -6,9 +6,12 @@
 const GAP_MS = 360;
 const SINGLE_DELAY_MS = 340;
 
-export function createTouchScheduledSingleAndDouble(onSingle: (key: number) => void, onDouble: (key: number) => void) {
+export function createTouchScheduledSingleAndDouble<Key extends string | number = number>(
+  onSingle: (key: Key) => void,
+  onDouble: (key: Key) => void,
+) {
   let lastEnd = 0;
-  let lastKey: number | null = null;
+  let lastKey: Key | null = null;
   let timer: number | null = null;
 
   function flushTimer() {
@@ -19,7 +22,7 @@ export function createTouchScheduledSingleAndDouble(onSingle: (key: number) => v
   /** 不在此调用 preventDefault，以免妨碍外层（如年视图）垂直滚动；防误触由位移阈值在业务侧处理 */
   function touchStart(_e: TouchEvent) {}
 
-  function touchEnd(key: number) {
+  function touchEnd(key: Key) {
     const now = Date.now();
     if (timer != null) flushTimer();
     if (lastKey === key && now - lastEnd < GAP_MS) {

--- a/src/composables/useViewportDebugSnapshot.ts
+++ b/src/composables/useViewportDebugSnapshot.ts
@@ -36,8 +36,7 @@ function readSafeAreaInsetsResolved(): { top: string; right: string; bottom: str
   }
   const el = document.createElement("div");
   el.setAttribute("data-viewport-debug-probe", "1");
-  el.style.cssText =
-    "position:fixed;left:-10000px;top:0;width:1px;height:1px;visibility:hidden;pointer-events:none;box-sizing:border-box;";
+  el.style.cssText = "position:fixed;left:-10000px;top:0;width:1px;height:1px;visibility:hidden;pointer-events:none;box-sizing:border-box;";
   el.style.paddingTop = "env(safe-area-inset-top, 0px)";
   el.style.paddingRight = "env(safe-area-inset-right, 0px)";
   el.style.paddingBottom = "env(safe-area-inset-bottom, 0px)";
@@ -59,7 +58,12 @@ function readRect(selector: string): ViewportDebugSnapshot["dom"]["app"] {
   const el = document.querySelector(selector);
   if (!el) return null;
   const r = el.getBoundingClientRect();
-  return { w: Math.round(r.width * 100) / 100, h: Math.round(r.height * 100) / 100, top: Math.round(r.top * 100) / 100, left: Math.round(r.left * 100) / 100 };
+  return {
+    w: Math.round(r.width * 100) / 100,
+    h: Math.round(r.height * 100) / 100,
+    top: Math.round(r.top * 100) / 100,
+    left: Math.round(r.left * 100) / 100,
+  };
 }
 
 export function captureViewportDebugSnapshot(): ViewportDebugSnapshot {
@@ -87,10 +91,7 @@ export function captureViewportDebugSnapshot(): ViewportDebugSnapshot {
   return {
     capturedAt: new Date().toISOString(),
     inner: { w: window.innerWidth, h: window.innerHeight },
-    outer:
-      window.outerWidth && window.outerHeight
-        ? { w: window.outerWidth, h: window.outerHeight }
-        : null,
+    outer: window.outerWidth && window.outerHeight ? { w: window.outerWidth, h: window.outerHeight } : null,
     screen: {
       w: window.screen?.width ?? 0,
       h: window.screen?.height ?? 0,
@@ -191,7 +192,8 @@ export function formatViewportDebugReport(s: ViewportDebugSnapshot): string {
 export function useViewportDebugSnapshot() {
   const snapshot = ref<ViewportDebugSnapshot | null>(null);
 
-  let debounceTimer: ReturnType<typeof window.setTimeout> | undefined;
+  // 浏览器定时器 ID 为 number；避免与 NodeJS.Timeout 在交叉类型下的不兼容
+  let debounceTimer: number | undefined;
 
   function refresh() {
     snapshot.value = captureViewportDebugSnapshot();

--- a/src/composables/useViewportDebugSnapshot.ts
+++ b/src/composables/useViewportDebugSnapshot.ts
@@ -36,8 +36,7 @@ function readSafeAreaInsetsResolved(): { top: string; right: string; bottom: str
   }
   const el = document.createElement("div");
   el.setAttribute("data-viewport-debug-probe", "1");
-  el.style.cssText =
-    "position:fixed;left:-10000px;top:0;width:1px;height:1px;visibility:hidden;pointer-events:none;box-sizing:border-box;";
+  el.style.cssText = "position:fixed;left:-10000px;top:0;width:1px;height:1px;visibility:hidden;pointer-events:none;box-sizing:border-box;";
   el.style.paddingTop = "env(safe-area-inset-top, 0px)";
   el.style.paddingRight = "env(safe-area-inset-right, 0px)";
   el.style.paddingBottom = "env(safe-area-inset-bottom, 0px)";
@@ -59,7 +58,12 @@ function readRect(selector: string): ViewportDebugSnapshot["dom"]["app"] {
   const el = document.querySelector(selector);
   if (!el) return null;
   const r = el.getBoundingClientRect();
-  return { w: Math.round(r.width * 100) / 100, h: Math.round(r.height * 100) / 100, top: Math.round(r.top * 100) / 100, left: Math.round(r.left * 100) / 100 };
+  return {
+    w: Math.round(r.width * 100) / 100,
+    h: Math.round(r.height * 100) / 100,
+    top: Math.round(r.top * 100) / 100,
+    left: Math.round(r.left * 100) / 100,
+  };
 }
 
 export function captureViewportDebugSnapshot(): ViewportDebugSnapshot {
@@ -87,10 +91,7 @@ export function captureViewportDebugSnapshot(): ViewportDebugSnapshot {
   return {
     capturedAt: new Date().toISOString(),
     inner: { w: window.innerWidth, h: window.innerHeight },
-    outer:
-      window.outerWidth && window.outerHeight
-        ? { w: window.outerWidth, h: window.outerHeight }
-        : null,
+    outer: window.outerWidth && window.outerHeight ? { w: window.outerWidth, h: window.outerHeight } : null,
     screen: {
       w: window.screen?.width ?? 0,
       h: window.screen?.height ?? 0,
@@ -191,7 +192,8 @@ export function formatViewportDebugReport(s: ViewportDebugSnapshot): string {
 export function useViewportDebugSnapshot() {
   const snapshot = ref<ViewportDebugSnapshot | null>(null);
 
-  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  // 浏览器定时器 ID 为 number；避免与 NodeJS.Timeout 在交叉类型下的不兼容
+  let debounceTimer: number | undefined;
 
   function refresh() {
     snapshot.value = captureViewportDebugSnapshot();

--- a/src/composables/useVisualViewportKeyboard.ts
+++ b/src/composables/useVisualViewportKeyboard.ts
@@ -1,0 +1,86 @@
+import { ref, computed } from "vue";
+
+/** 低于该值视为 UI 抖动（地址栏等），不当作软键盘 */
+const OBSCURED_BOTTOM_THRESHOLD_PX = 36;
+/** FAB 与键盘顶缘的留白 */
+const FAB_CLEARANCE_ABOVE_KEYBOARD_PX = 10;
+
+function readInnerSize() {
+  if (typeof window === "undefined") return { h: 600, w: 400 };
+  const vv = window.visualViewport;
+  return {
+    h: vv?.height ?? window.innerHeight,
+    w: vv?.width ?? window.innerWidth,
+  };
+}
+
+function readObscuredBottomPx(): number {
+  if (typeof window === "undefined") return 0;
+  const vv = window.visualViewport;
+  if (!vv) return 0;
+  return Math.max(0, Math.round(window.innerHeight - vv.offsetTop - vv.height));
+}
+
+/**
+ * 基于 visualViewport 同步「可用视口」尺寸与底部被遮挡高度（软键盘 / iOS 输入条）。
+ * rootCssVars 供页面根节点绑定，子组件通过继承使用 CSS 变量。
+ */
+export function useVisualViewportKeyboard() {
+  const { h: ih, w: iw } = readInnerSize();
+  const viewportInnerH = ref(ih);
+  const viewportInnerW = ref(iw);
+  const obscuredBottomRawPx = ref(typeof window !== "undefined" ? readObscuredBottomPx() : 0);
+
+  function syncFromVisualViewport() {
+    if (typeof window === "undefined") return;
+    const vv = window.visualViewport;
+    if (vv) {
+      viewportInnerH.value = vv.height;
+      viewportInnerW.value = vv.width;
+      obscuredBottomRawPx.value = readObscuredBottomPx();
+    } else {
+      viewportInnerH.value = window.innerHeight;
+      viewportInnerW.value = window.innerWidth;
+      obscuredBottomRawPx.value = 0;
+    }
+  }
+
+  const obscuredBottomEffectivePx = computed(() => {
+    const r = obscuredBottomRawPx.value;
+    return r >= OBSCURED_BOTTOM_THRESHOLD_PX ? r : 0;
+  });
+
+  /** 绑定到 Home 根节点，MobileHomeFab / ActivitySheet 继承 */
+  const rootCssVars = computed(() => {
+    const obscured = obscuredBottomEffectivePx.value;
+    const fabLift = obscured > 0 ? obscured + FAB_CLEARANCE_ABOVE_KEYBOARD_PX : 0;
+    return {
+      "--vv-obscured-bottom": `${obscured}px`,
+      "--vv-fab-lift": `${fabLift}px`,
+    } as Record<string, string>;
+  });
+
+  function attachListeners() {
+    if (typeof window === "undefined") return;
+    syncFromVisualViewport();
+    window.addEventListener("resize", syncFromVisualViewport);
+    window.visualViewport?.addEventListener("resize", syncFromVisualViewport);
+    window.visualViewport?.addEventListener("scroll", syncFromVisualViewport);
+  }
+
+  function detachListeners() {
+    if (typeof window === "undefined") return;
+    window.removeEventListener("resize", syncFromVisualViewport);
+    window.visualViewport?.removeEventListener("resize", syncFromVisualViewport);
+    window.visualViewport?.removeEventListener("scroll", syncFromVisualViewport);
+  }
+
+  return {
+    viewportInnerH,
+    viewportInnerW,
+    rootCssVars,
+    syncFromVisualViewport,
+    attachListeners,
+    detachListeners,
+  };
+}

--- a/src/composables/useWeekData.ts
+++ b/src/composables/useWeekData.ts
@@ -6,6 +6,7 @@ import type { Todo } from "@/core/types/Todo";
 import type { Schedule } from "@/core/types/Schedule";
 import type { UnifiedItem } from "@/core/types/Week";
 import { startOfDay } from "@/core/utils/weekDays";
+import { countCompletedPomos } from "@/services/realPomoState";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const STANDARD_POMO = 16;
@@ -106,10 +107,7 @@ export function useWeekData() {
       const sumRealPomo = sorted
         .filter((i) => i.type === "todo" && i.pomoType === "🍅")
         .reduce((sum, item) => {
-          const arr = (item as any).realPomo;
-          if (!Array.isArray(arr) || arr.length === 0) return sum;
-          const itemSum = arr.reduce((s: number, n: number) => s + (Number(n) || 0), 0);
-          return sum + itemSum;
+          return sum + countCompletedPomos(item as unknown as Todo);
         }, 0);
 
       const sumRealGrape = sorted

--- a/src/composables/useWeekData.ts
+++ b/src/composables/useWeekData.ts
@@ -102,13 +102,13 @@ export function useWeekData() {
       const dayTs = weekStart + idx * DAY_MS;
       const sorted = buckets[idx].slice().sort((a, b) => a.ts - b.ts);
 
-      // Pomo统计
+      // Pomo统计 - 使用 countCompletedPomos 统一（支持扁平三态）
       const sumRealPomo = sorted
         .filter((i) => i.type === "todo" && i.pomoType === "🍅")
         .reduce((sum, item) => {
-          const arr = item.realPomo;
+          const arr = (item as any).realPomo;
           if (!Array.isArray(arr) || arr.length === 0) return sum;
-          const itemSum = arr.reduce((s, n) => s + (Number(n) || 0), 0);
+          const itemSum = arr.reduce((s: number, n: number) => s + (Number(n) || 0), 0);
           return sum + itemSum;
         }, 0);
 

--- a/src/core/types/Todo.ts
+++ b/src/core/types/Todo.ts
@@ -8,7 +8,7 @@ export interface Todo {
   projectName?: string;
   taskId?: number; // 只需1个task
   estPomo?: number[]; // 最多3次估计
-  realPomo?: number[]; // 最多3次实际
+  realPomo?: number[]; // 扁平 per-slot 状态数组：0=未做 / 1=完成 / -1=作废；长度=sum(estPomo)；兼容旧版（每段一个前缀计数）
   status?: "" | "delayed" | "ongoing" | "cancelled" | "done" | "suspended";
   priority: number;
   pomoType?: "🍅" | "🍇" | "🍒";

--- a/src/services/chartDataService.ts
+++ b/src/services/chartDataService.ts
@@ -1,26 +1,31 @@
-// src/services/chatDataService.ts
+// src/services/chartDataService.ts
 import type { Todo } from "@/core/types/Todo";
 import type { Task } from "@/core/types/Task";
 import type { DataPoint, TimeGranularity, AggregationType, DateString } from "@/core/types/Chart";
 import { METRICS } from "@/core/types/Metrics";
+import { countCompletedPomos } from "./realPomoState";
 
 // ============ 数据收集 ============
 
 /**
  * 从Todo收集番茄数据
- * realPomo: [1,3,4] → 总和8个番茄
+ * 现在使用 countCompletedPomos（仅统计 realPomo 中 ===1 的个数，-1 作废不计入）
+ * 樱桃 🍒 内部已处理 /2 兼容旧行为
  */
 export function collectPomodoroData(todos: Todo[]): DataPoint[] {
   return todos
     // 软删除的 Todo 仍留在列表中，统计与图表不应再计入其番茄
     .filter((t) => !t.deleted)
-    .filter((t) => t.realPomo && t.realPomo.length > 0 && t.pomoType === "🍅")
-    .map((t) => ({
-      metric: METRICS.POMODORO,
-      timestamp: t.doneTime || t.id,
-      value: t.realPomo!.reduce((sum, pomo) => sum + pomo, 0),
-      sourceId: t.id,
-    }))
+    .filter((t) => t.pomoType === "🍅")
+    .map((t) => {
+      const completed = countCompletedPomos(t);
+      return {
+        metric: METRICS.POMODORO,
+        timestamp: t.doneTime || t.id,
+        value: completed,
+        sourceId: t.id,
+      };
+    })
     .filter((point) => point.value > 0);
 }
 
@@ -151,7 +156,8 @@ function applyAggregation(points: DataPoint[], method: AggregationType): number 
 
   switch (method) {
     case "sum":
-      return values.reduce((a, b) => a + b, 0);
+      // 防御：排除可能的负值（-1 作废），防止其他 metric 误传
+      return values.reduce((a, b) => a + Math.max(0, b), 0);
 
     case "avg":
       return values.reduce((a, b) => a + b, 0) / values.length;

--- a/src/services/importNormalizationService.ts
+++ b/src/services/importNormalizationService.ts
@@ -4,6 +4,7 @@ import type { Todo } from "@/core/types/Todo";
 import type { Block, PomodoroSegment } from "@/core/types/Block";
 import { splitIndexPomoBlocksExSchedules } from "@/services/pomoSegService";
 import type { Schedule } from "@/core/types/Schedule";
+import { countCompletedPomos } from "./realPomoState";
 
 export interface TodoNormalizationStats {
   normalizedCount: number;
@@ -38,9 +39,9 @@ function createEmptyStats(): TodoNormalizationStats {
 }
 
 function getRealPomoTotal(todo: Todo): number {
-  if (!Array.isArray(todo.realPomo) || todo.realPomo.length === 0) return 1;
-  const sum = todo.realPomo.reduce((acc, cur) => acc + (typeof cur === "number" && Number.isFinite(cur) ? cur : 0), 0);
-  return Math.max(1, Math.floor(sum));
+  // 使用新统计口径（完成数），用于 globalIndex 回填等逻辑
+  const completed = countCompletedPomos(todo);
+  return Math.max(1, completed);
 }
 
 function getDayStart(ts: number): number {

--- a/src/services/pomoSegService.ts
+++ b/src/services/pomoSegService.ts
@@ -2,6 +2,7 @@
 import type { Block, TodoSegment, PomodoroSegment } from "@/core/types/Block";
 import type { Todo } from "@/core/types/Todo";
 import { getTimestampForTimeString } from "@/core/utils";
+import { countCompletedPomos } from "./realPomoState";
 
 // ========== 辅助工具函数 ==========
 
@@ -43,14 +44,10 @@ function _getTodoEstPomoCount(todo: Todo): number {
 
 /**
  * 统计 todo 实际完成番茄数
+ * 现在统一使用 realPomoState.countCompletedPomos（支持扁平 0/1/-1，樱桃兼容 /2）
  */
 function _getTodoRealPomoCount(todo: Todo): number {
-  if (!todo.realPomo) return 0;
-  const rawCount = todo.realPomo.reduce((sum, cur) => sum + (typeof cur === "number" ? cur : 0), 0);
-  if (todo.pomoType === "🍒") {
-    return rawCount / 2;
-  }
-  return rawCount;
+  return countCompletedPomos(todo);
 }
 
 // ========== 番茄时间段生成（第一列） ==========

--- a/src/services/realPomoState.ts
+++ b/src/services/realPomoState.ts
@@ -1,0 +1,138 @@
+// src/services/realPomoState.ts
+// realPomo 扁平三态工具（0 未做 / 1 完成 / -1 作废）
+// 保持 estPomo 与云端 real_pomo 为 number[] 不变，集中迁移/统计逻辑
+// 代码注释使用中文
+
+import type { Todo } from "@/core/types/Todo";
+
+/**
+ * 计算 todo 的总槽位数（totalSlots）
+ * - 普通 🍅/🍇 ：sum(estPomo)
+ * - 樱桃 🍒 ：estPomo[0] （通常为 4，对应 4 个 15min 槽位）
+ */
+export function totalSlots(todo: Todo): number {
+  if (!todo.estPomo || !Array.isArray(todo.estPomo) || todo.estPomo.length === 0) {
+    return 0;
+  }
+  const sum = todo.estPomo.reduce((acc, v) => acc + (typeof v === "number" && Number.isFinite(v) ? v : 0), 0);
+  if (todo.pomoType === "🍒") {
+    return Math.max(4, sum); // 樱桃固定 4 槽位（或根据 est[0]）
+  }
+  return sum;
+}
+
+/**
+ * 判断是否为旧格式（legacy）：realPomo.length === estPomo.length 且与 totalSlots 不等
+ * 旧格式下每个 est[i] 表示该段的前缀完成数
+ */
+function isLegacyFormat(todo: Todo): boolean {
+  if (!todo.realPomo || !Array.isArray(todo.realPomo) || !todo.estPomo || !Array.isArray(todo.estPomo)) {
+    return false;
+  }
+  const estLen = todo.estPomo.length;
+  const realLen = todo.realPomo.length;
+  return realLen === estLen && realLen !== totalSlots(todo);
+}
+
+/**
+ * 将旧格式展开为扁平新格式
+ * 旧 [v1, v2] + estPomo=[3,2] → 前 v1 个 1，后补 0；第二段前 v2 个 1
+ */
+function expandLegacyToFlat(todo: Todo): number[] {
+  if (!todo.realPomo || !todo.estPomo) return [];
+  const flat: number[] = [];
+  let slotIdx = 0;
+
+  for (let i = 0; i < todo.estPomo.length; i++) {
+    const est = typeof todo.estPomo[i] === "number" ? todo.estPomo[i]! : 0;
+    const completedInSeg = typeof todo.realPomo[i] === "number" ? Math.max(0, Math.min(todo.realPomo[i]!, est)) : 0;
+
+    for (let j = 0; j < est; j++) {
+      flat[slotIdx++] = j < completedInSeg ? 1 : 0;
+    }
+  }
+  return flat;
+}
+
+/**
+ * 确保 realPomo 是扁平格式（长度 = totalSlots），旧数据自动迁移
+ * 写路径始终产生新格式
+ */
+export function ensureFlatRealPomo(todo: Todo): number[] {
+  if (!todo.realPomo || !Array.isArray(todo.realPomo)) {
+    return new Array(totalSlots(todo)).fill(0);
+  }
+
+  const slots = totalSlots(todo);
+  if (todo.realPomo.length === slots) {
+    // 已为新格式，钳制值到合法范围
+    return todo.realPomo.map((v) => {
+      if (v === 1 || v === -1) return v;
+      return 0;
+    });
+  }
+
+  if (isLegacyFormat(todo)) {
+    return expandLegacyToFlat(todo);
+  }
+
+  // 其他情况（长度不匹配或空）返回全 0 扁平数组
+  return new Array(slots).fill(0);
+}
+
+/**
+ * 获取指定槽位的状态（0/1/-1）
+ * slotIndex = sum(estPomo[0..estIndex-1]) + (pomoIndex-1)
+ */
+export function getRealPomoState(todo: Todo, slotIndex: number): number {
+  const flat = ensureFlatRealPomo(todo);
+  if (slotIndex < 0 || slotIndex >= flat.length) return 0;
+  const v = flat[slotIndex];
+  return v === 1 || v === -1 ? v : 0;
+}
+
+/**
+ * 设置指定槽位的状态，并返回更新后的 realPomo 数组（始终扁平）
+ */
+export function setPomoState(todo: Todo, slotIndex: number, state: 0 | 1 | -1): number[] {
+  const flat = ensureFlatRealPomo(todo);
+  if (slotIndex < 0 || slotIndex >= flat.length) return flat;
+
+  flat[slotIndex] = state;
+  return [...flat]; // 返回副本供 emit 使用
+}
+
+/**
+ * 计算完成番茄数（仅计 1 的个数，-1 不计入）
+ * - 樱桃：仍保持 /2 以兼容旧时间轴逻辑（ones / 2）
+ */
+export function countCompletedPomos(todo: Todo): number {
+  const flat = ensureFlatRealPomo(todo);
+  const ones = flat.filter((v) => v === 1).length;
+
+  if (todo.pomoType === "🍒") {
+    return Math.floor(ones / 2); // 保持与旧 sum(realPomo)/2 一致
+  }
+  return ones;
+}
+
+/**
+ * 判断 todo 是否已有进度（用于 !realPomo 提示逻辑）
+ * 有任意 1 或 -1 即视为已开始
+ */
+export function hasAnyProgress(todo: Todo): boolean {
+  const flat = ensureFlatRealPomo(todo);
+  return flat.some((v) => v === 1 || v === -1);
+}
+
+/**
+ * 计算指定 estIndex 段的起始 slotIndex（供 DayTodo 扁平索引使用）
+ */
+export function getSlotIndexForEst(todo: Todo, estIndex: number, pomoIndex: number): number {
+  if (!todo.estPomo || estIndex < 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < estIndex; i++) {
+    sum += typeof todo.estPomo[i] === "number" ? todo.estPomo[i]! : 0;
+  }
+  return sum + (pomoIndex - 1);
+}

--- a/src/services/todoSegService.ts
+++ b/src/services/todoSegService.ts
@@ -1,6 +1,7 @@
 import type { TodoSegment, PomodoroSegment } from "@/core/types/Block";
 import type { Todo } from "@/core/types/Todo";
 import { SPECIAL_PRIORITIES } from "@/core/priorityCategories";
+import { countCompletedPomos } from "./realPomoState";
 
 // ========== Todo 估计分配相关工具函数（第二列） ==========
 
@@ -18,14 +19,10 @@ function _getTodoEstPomoCount(todo: Todo): number {
 
 /**
  * 统计 todo 实际完成番茄数
+ * 现在统一使用 realPomoState.countCompletedPomos（支持扁平三态，樱桃兼容）
  */
 function _getTodoRealPomoCount(todo: Todo): number {
-  if (!todo.realPomo) return 0;
-  const rawCount = todo.realPomo.reduce((sum, cur) => sum + (typeof cur === "number" ? cur : 0), 0);
-  if (todo.pomoType === "🍒") {
-    return rawCount / 2;
-  }
-  return rawCount;
+  return countCompletedPomos(todo);
 }
 
 /**

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -433,7 +433,7 @@ const onDayJump = () => {
 // 年视图中点击月份标题 → 进入月视图并定位到该月
 const onYearNavigateToMonth = (monthStartTs: number) => {
   settingStore.settings.viewSet = "month";
-  settingStore.settings.topHeight = isMobile.value ? 525 : 610;
+  settingStore.settings.topHeight = isMobile.value ? 525 : 615;
   dateService.navigateTo(monthStartTs);
 };
 
@@ -447,7 +447,7 @@ const onYearNavigateToWeek = (weekStartTs: number) => {
 // weekplanner month 引起变化日期
 const onMonthJump = () => {
   settingStore.settings.viewSet = "month";
-  settingStore.settings.topHeight = isMobile.value ? 525 : 610;
+  settingStore.settings.topHeight = isMobile.value ? 580 : 610;
 };
 
 const onWeekJump = () => {
@@ -1253,11 +1253,11 @@ function onViewSet() {
   const next = order[(idx + 1) % order.length];
   settingStore.settings.viewSet = next;
   if (cur === "week") {
-    settingStore.settings.topHeight = 610;
+    settingStore.settings.topHeight = 615;
   } else if (cur === "day") {
-    settingStore.settings.topHeight = 610;
+    settingStore.settings.topHeight = 600;
   } else if (cur === "month") {
-    settingStore.settings.topHeight = 480;
+    settingStore.settings.topHeight = 450;
   } else if (cur === "year") {
     settingStore.settings.topHeight = 300;
   }
@@ -1531,7 +1531,7 @@ const isLandscapeViewport = computed(() => viewportInnerW.value > viewportInnerH
 const effectiveMiddleTopHeightPx = computed(() => {
   if (!settingStore.settings.showPlanner || !settingStore.settings.showTask) return topHeight.value;
   const avail = Math.max(180, viewportInnerH.value - 24);
-  const minTask = 140;
+  const minTask = 100;
   const maxTop = Math.max(120, avail - minTask);
   if (!isMobile.value) {
     return topHeight.value + minTask > avail ? Math.min(topHeight.value, maxTop) : topHeight.value;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -5,7 +5,8 @@
 -->
 
 <template>
-  <div class="home-content">
+  <div class="home-root" :style="rootCssVars">
+    <div class="home-content">
     <!-- 左侧面板 (日程表) -->
     <div v-if="settingStore.settings.showSchedule" class="left" :style="{ width: leftWidth + 'px' }">
       <TimeTable @timetable-edit="onTimetableEdit" />
@@ -284,33 +285,34 @@
       <!-- AI 对话对话框 -->
       <AIChatDialog />
     </div>
+    </div>
+    <MobileHomeFab
+      v-if="isMobile"
+      :task-record-editing="taskRecordEditing"
+      @notify="showErrorPopover"
+      @update-active-id="onUpdateActiveId"
+      @pick-activity="onPickActivity"
+      @delete-activity="onDeleteActivity"
+      @create-child-activity="onCreateChildActivity"
+      @increase-child-activity="onIncreaseChildActivity"
+      @quick-add-todo="onQuickAddTodo"
+      @quick-add-schedule="onQuickAddSchedule"
+      @add-activity="onAddActivity"
+      @reset-to-present="onMobileFabResetToPresent"
+      @cancel-planner-row="onMobileFabCancelPlannerRow"
+      @suspend-planner-row="onMobileFabSuspendPlannerRow"
+      @repeat-activity="onRepeatActivity"
+      @finish-task-record-editing="onFinishTaskRecordEditing"
+    />
+    <!-- 错误提示弹窗 -->
+    <n-popover v-model:show="showPopover" trigger="manual" placement="top-end" style="width: 200px">
+      <template #trigger>
+        <div style="position: fixed; bottom: 20px; right: 20px; width: 1px; height: 1px"></div>
+      </template>
+      {{ popoverMessage }}
+    </n-popover>
+    <IcsExportModal v-if="icsModalVisible" :visible="icsModalVisible" :qrText="icsQRText" @close="icsModalVisible = false" />
   </div>
-  <MobileHomeFab
-    v-if="isMobile"
-    :task-record-editing="taskRecordEditing"
-    @notify="showErrorPopover"
-    @update-active-id="onUpdateActiveId"
-    @pick-activity="onPickActivity"
-    @delete-activity="onDeleteActivity"
-    @create-child-activity="onCreateChildActivity"
-    @increase-child-activity="onIncreaseChildActivity"
-    @quick-add-todo="onQuickAddTodo"
-    @quick-add-schedule="onQuickAddSchedule"
-    @add-activity="onAddActivity"
-    @reset-to-present="onMobileFabResetToPresent"
-    @cancel-planner-row="onMobileFabCancelPlannerRow"
-    @suspend-planner-row="onMobileFabSuspendPlannerRow"
-    @repeat-activity="onRepeatActivity"
-    @finish-task-record-editing="onFinishTaskRecordEditing"
-  />
-  <!-- 错误提示弹窗 -->
-  <n-popover v-model:show="showPopover" trigger="manual" placement="top-end" style="width: 200px">
-    <template #trigger>
-      <div style="position: fixed; bottom: 20px; right: 20px; width: 1px; height: 1px"></div>
-    </template>
-    {{ popoverMessage }}
-  </n-popover>
-  <IcsExportModal v-if="icsModalVisible" :visible="icsModalVisible" :qrText="icsQRText" @close="icsModalVisible = false" />
 </template>
 
 <script setup lang="ts">
@@ -323,6 +325,7 @@ import type { Activity } from "@/core/types/Activity";
 import { getTimestampForTimeString } from "@/core/utils";
 import { ViewType } from "@/core/constants";
 import { useResize } from "@/composables/useResize";
+import { useVisualViewportKeyboard } from "@/composables/useVisualViewportKeyboard";
 import IcsExportModal from "@/components/IcsExportModal.vue";
 import HomeTagFilterPopover from "@/components/TagSystem/HomeTagFilterPopover.vue";
 import MobileHomeFab from "@/components/MobileHomeFab/MobileHomeFab.vue";
@@ -353,6 +356,13 @@ import { useDevice } from "@/composables/useDevice";
 // ======================== 响应式状态与初始化 ========================
 // 不直接import Naive和以下组建加速启动
 const { isMobile } = useDevice();
+const {
+  viewportInnerH,
+  viewportInnerW,
+  rootCssVars,
+  attachListeners: attachVisualViewportListeners,
+  detachListeners: detachVisualViewportListeners,
+} = useVisualViewportKeyboard();
 const TimeTable = defineAsyncComponent(() => import("@/components/TimeTable/TimeTable.vue"));
 const DayPlanner = defineAsyncComponent(() => import("@/components/DayPlanner/DayPlanner.vue"));
 const WeekPlanner = defineAsyncComponent(() => import("@/components/WeekPlanner/WeekPlanner.vue"));
@@ -1469,35 +1479,18 @@ function handleEditScheduleLocation(id: number, newLocation: string) {
   saveAllDebounced();
 }
 
-// visualViewport 尺寸需在 onMounted 前定义，供生命周期里注册监听
-const viewportInnerH = ref(typeof window !== "undefined" ? window.innerHeight : 600);
-const viewportInnerW = ref(typeof window !== "undefined" ? window.innerWidth : 400);
-
-function syncHomeViewportDims() {
-  if (typeof window === "undefined") return;
-  viewportInnerH.value = window.visualViewport?.height ?? window.innerHeight;
-  viewportInnerW.value = window.visualViewport?.width ?? window.innerWidth;
-}
-
 // ======================== 8. 生命周期 Hook ========================
 onMounted(() => {
   // console.log("HomeView mounted");
   dateService.setupSystemDateWatcher();
   dateService.navigateByView("today");
-  if (typeof window !== "undefined") {
-    syncHomeViewportDims();
-    window.addEventListener("resize", syncHomeViewportDims);
-    window.visualViewport?.addEventListener("resize", syncHomeViewportDims);
-  }
+  attachVisualViewportListeners();
 });
 
 onUnmounted(() => {
   dateService.cleanupSystemDateWatcher();
   autoSyncDebounced.flush(); //立即执行
-  if (typeof window !== "undefined") {
-    window.removeEventListener("resize", syncHomeViewportDims);
-    window.visualViewport?.removeEventListener("resize", syncHomeViewportDims);
-  }
+  detachVisualViewportListeners();
 });
 
 //  路由切换前保存（Vue Router）
@@ -1559,13 +1552,22 @@ const { startResize: startRightResize } = useResize(
 </script>
 
 <style scoped>
+.home-root {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 .home-content {
   display: flex;
+  flex: 1 1 auto;
+  flex-direction: row;
+  min-height: 0;
+  overflow: hidden;
   background: var(--color-background-light-light);
   justify-content: center;
-  overflow: hidden;
-  height: 100%;
-  flex-direction: row;
 }
 
 .left {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -419,10 +419,10 @@ const isViewDateYesterday = computed(() => dateService.isViewDateYesterday);
 const isViewDateTomorrow = computed(() => dateService.isViewDateTomorrow);
 const appDateTimestamp = computed(() => dateService.appDateTimestamp);
 
-// 进入年视图（点击头部年份）
+// 进入年视图（点击头部年份） #HACK
 const onYearJump = () => {
   settingStore.settings.viewSet = "year";
-  settingStore.settings.topHeight = 490;
+  settingStore.settings.topHeight = isMobile.value ? 440 : 450;
 };
 
 const onDayJump = () => {
@@ -433,26 +433,26 @@ const onDayJump = () => {
 // 年视图中点击月份标题 → 进入月视图并定位到该月
 const onYearNavigateToMonth = (monthStartTs: number) => {
   settingStore.settings.viewSet = "month";
-  settingStore.settings.topHeight = isMobile.value ? 525 : 615;
+  settingStore.settings.topHeight = isMobile.value ? 435 : 610;
   dateService.navigateTo(monthStartTs);
 };
 
 // 年视图中点击周编号 → 进入周视图并定位到该周
 const onYearNavigateToWeek = (weekStartTs: number) => {
   settingStore.settings.viewSet = "week";
-  settingStore.settings.topHeight = isMobile.value ? 490 : 510;
+  settingStore.settings.topHeight = isMobile.value ? 435 : 610;
   dateService.navigateTo(weekStartTs);
 };
 
 // weekplanner month 引起变化日期
 const onMonthJump = () => {
   settingStore.settings.viewSet = "month";
-  settingStore.settings.topHeight = isMobile.value ? 580 : 610;
+  settingStore.settings.topHeight = isMobile.value ? 435 : 610;
 };
 
 const onWeekJump = () => {
   settingStore.settings.viewSet = "week";
-  settingStore.settings.topHeight = isMobile.value ? 490 : 510;
+  settingStore.settings.topHeight = isMobile.value ? 435 : 610;
 };
 
 // 选择进入日视图的具体日期
@@ -1253,9 +1253,9 @@ function onViewSet() {
   const next = order[(idx + 1) % order.length];
   settingStore.settings.viewSet = next;
   if (cur === "week") {
-    settingStore.settings.topHeight = 615;
+    settingStore.settings.topHeight = 610;
   } else if (cur === "day") {
-    settingStore.settings.topHeight = 600;
+    settingStore.settings.topHeight = 610;
   } else if (cur === "month") {
     settingStore.settings.topHeight = 450;
   } else if (cur === "year") {


### PR DESCRIPTION



# [S2 C1 UV1] Fab按钮+作废番茄改造+tagSelector输入行为+planner 切换高度一致

## Summary

本次改动聚焦于 planner、mobile 交互、timer 输入区以及发布构建稳定性，主要包括：

- 修复 `TagSelector` 在 planner 中的对齐问题，并增强键盘可用性（回车 / 上下键可选中），同时支持移动端点击选择
- 修复 release 打包错误，恢复构建流程稳定性
- 修复 activity 删除按钮对应的错误行为
- 调整 planner 区域高度切换逻辑，并确认移动端 app 下 planner 高度切换表现
- 引入统计相关能力（番茄酱 `feat(stat)`，包含较多 HACK 型改动）
- 增加双击与 checkbox 的兼容交互，并修复移动端“双击作废”问题
- 修复移动端按钮状态与选中状态的联动关系
- 实现 visual viewport 方案，用于移动端键盘弹出时的布局自适应，并同步更新相关样式
- 取消 sequenceTimer 输入框的高度调整，避免输入态下布局抖动

## Scope

- planner/tag selector 交互与布局
- mobile 端点击/双击与选中态行为
- timer 输入区 UI 稳定性
- viewport 键盘适配
- release 构建修复
- stat 功能增量

## Test Plan

- [x] 桌面端验证 planner 中 TagSelector 对齐与键盘选择行为（Enter / ArrowUp / ArrowDown）
- [x] 移动端验证 TagSelector 可点击选择
- [x] 验证 activity 删除按钮行为正确
- [x] 验证 planner 高度切换在桌面与移动端表现一致
- [x] 验证 checkbox 双击交互兼容性
- [x] 验证移动端按钮选中联动及“双击作废”场景
- [x] 验证移动端软键盘弹出/收起时 visual viewport

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pomodoro progress representation and multiple read/write paths (UI interactions, stats, import/segmentation), so regressions could affect progress persistence and reporting; changes are localized but behaviorally significant.
> 
> **Overview**
> Unifies `Todo.realPomo` into a **flat per-slot tri-state array** (`0`/`1`/`-1` void) via new `realPomoState` helpers, and switches stats/aggregation paths (`chartDataService`, week/month views, import normalization, segment services) to count completed slots consistently (void slots excluded).
> 
> Updates Day planner UI to match the new model: pomodoro checkboxes read/write by slot index, adds **double-click / double-tap to void a slot** with debounce/suppression to avoid checkbox events overwriting void state, and tightens cancel/suspend gating to “no progress” rather than “no `realPomo`”.
> 
> Improves planner tag selection UX by embedding `TagPickerPopover` inside the editing cell and routing Enter/arrow keys and blur handling so keyboard selection and touch selection don’t prematurely save/close. Adds visualViewport-based CSS vars to lift the FAB and avoid iOS safe-area gray bars when the keyboard is open, plus small layout/style tweaks (planner empty-row height, textarea resize suppression, passive touchstart on tag panel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3482b13a314e2089dff3c5f17d94e4a39b4c9559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->