### PR TITLE
[S1 C1 UV1] 四象限功能v2

### DIFF
--- a/.cursor/skills/dev-branch/SKILL.md
+++ b/.cursor/skills/dev-branch/SKILL.md
@@ -3,8 +3,9 @@ name: dev-branch
 description: >-
   Recreates `dev` from latest `main` after merge-delete: verify with
   `git fetch origin --prune`, confirm `origin/dev` gone or merged into main,
-  checkout main, pull --prune, delete local dev, fetch --prune again, new dev,
-  push -u. No force-push. Use for dev-branch / 重建 dev.
+  checkout main, pull --prune, force-move local `dev` to `main` (`branch -f`),
+  fetch --prune, checkout dev, verify main===dev, push -u. No force-push.
+  Use for dev-branch / 重建 dev.
 ---
 
 # 重建并发布 `dev` 分支
@@ -15,6 +16,12 @@ description: >-
 - 本地只是在 `main` 最新基础上 **新建同名 `dev` 并首次推送**，**不需要、也不使用强推**。
 
 若远端仍残留 **独立提交** 的 `dev`（未进 `main`），应先 **合并 PR** 或在托管端处理后再继续；**勿**对 `dev` 做 `--force`。
+
+## 为何不用「删分支再 `checkout -b`」（重要）
+
+旧版流程里若 **`git branch -d dev` 失败**（Git 认为旧 `dev` 未合并进当前 `HEAD`），后续 **`git checkout -b dev` 也会失败**（本地 `dev` 仍存在），但若脚本**继续执行** `git push -u origin dev`，会把**仍指向合并前提交**的本地 `dev` 推上去，等于把「已合进 main 的旧历史」又发布到远端。
+
+**正确做法**：在 `main` 更新到最新后，用 **`git branch -f dev main`（或不存在时 `git branch dev main`）** 把本地 `dev` **强制指向与 `main` 相同的提交**，再 `checkout` 与 `push`。这样不依赖「删除分支是否成功」，也不会误推旧指针。
 
 ## 执行前核对（Agent / 人类先做）
 
@@ -41,33 +48,39 @@ description: >-
 ```bash
 git checkout main
 git pull --prune
-git branch -d dev
 git fetch origin --prune
-git checkout -b dev
+git branch -f dev main || git branch dev main
+git checkout dev
+# 推送前校验：main 与 dev 必须为同一提交，否则禁止 push
+test "$(git rev-parse main)" = "$(git rev-parse dev)"
 git push -u origin dev
 ```
 
 说明：
 
-- **`git pull --prune`**：在 `main` 上快进更新；`--prune` 有助于同步远端已删除分支的跟踪引用，**不能**替代下面单独一次的 **`fetch --prune`**（删本地 `dev` 后清理 stale `origin/dev` 的场景）。
-- **`git branch -d dev`**：上一支已合并进 `main` 时通常可删；若 Git 提示未合并、但你确认无保留价值，再改用 `git branch -D dev`。
-- **`git fetch origin --prune`**（在删除本地 `dev` 之后）：若托管已删远端 `dev`，此处会移除本地的 `remotes/origin/dev`，避免后续误判。
-- **`git push -u origin dev`**：远端无同名分支时即创建并设置上游。
+- **`git pull --prune`**：在 `main` 上快进更新；`--prune` 有助于同步远端已删除分支的跟踪引用。
+- **`git fetch origin --prune`**：清掉托管已删分支对应的 `origin/*`，避免误判远端是否还有 `dev`。
+- **`git branch -f dev main || git branch dev main`**：已有本地 `dev` 时用 `-f` 把它移到 `main` 当前提交；若本地尚无 `dev`，`-f` 会失败，用第二条命令创建与 `main` 同提交的 `dev`。**不要用 `git branch -d dev` 作为唯一手段**，以免删失败后误推旧指针。
+- **`test "$(git rev-parse main)" = "$(git rev-parse dev)"`**：Agent 或脚本在 push 前必须满足；失败则**停止**，检查是否未切到 `dev`、或 `branch -f` 未执行成功。**Windows CMD** 无 `test`，可改用 PowerShell：`if ((git rev-parse main) -ne (git rev-parse dev)) { exit 1 }`。
+- **`git push -u origin dev`**：远端无同名分支时即创建并设置上游；此时本地 `dev` 已与 `main` 同提交，推送的是**最新 main 线**，不是旧的合并前 `dev`。
+
+## 可选：仍希望删掉旧本地 `dev` 再重建
+
+在已确认 **`git merge-base --is-ancestor dev main`**（旧 `dev` 已在 `main` 历史内）或确认无独有提交后，可在 **`git branch -f dev main` 之前**执行 `git branch -D dev`，再 `git branch dev main`。这是锦上添花；**核心安全绳仍是 `-f`/`branch dev main` + rev-parse 校验**。
 
 ## 常见异常
 
 - **`git pull` 报错**：`Your configuration specifies to merge with the ref 'refs/heads/dev' from the remote, but no such ref was fetched.`  
   **原因**：当前在 **`dev`** 上，且上游仍指向托管端**已删除**的 `dev`。  
-  **处理**：**先 `git checkout main`**，更新 `main`，再删本地 `dev`；不要停在 `dev` 上反复 `pull`。
+  **处理**：**先 `git checkout main`**，更新 `main`，再按标准命令把 `dev` 指到 `main`；不要停在 `dev` 上反复 `pull`。
 
-- **`git branch -d dev` 警告**：deleting branch merged to `refs/remotes/origin/dev`, but not yet merged to **HEAD**。  
-  **原因**：已切到 `main` 时，`main` 的 HEAD 未必包含旧跟踪分支视角下的「合并」表述；若你已确认 PR 已合入 `main`，通常可继续；执意删除可用 `-D`（确认无独有提交后再用）。
-
-- **当前在 `dev` 上**：先 `git checkout main`，再删 `dev`。
+- **当前在 `dev` 上**：先 `git checkout main`，再执行标准命令。
 - **`main` 名不同**：`checkout` / `pull` 改为实际默认分支名。
 - **remote 非 `origin`**：凡写 `origin` 处替换为实际 remote。
+- **PowerShell 串联命令**：旧版 PowerShell 可能不支持 `&&`；可分行执行，或用 `;` 分隔（注意失败时仍会继续执行后续命令，关键步骤建议单独跑并看退出码）。
 
 ## 反例
 
 - 在「合并后删除」未生效、远端 `dev` 仍有未进 `main` 的提交时，强行用「从 `main` 新建的 dev」去覆盖远端。
-- 工作区有未保存修改就删分支、切分支。
+- 工作区有未保存修改就切分支、改分支指针。
+- **`git branch -d dev` / `checkout -b dev` 任一步失败后仍执行 `git push -u origin dev`**（未先把 `dev` 对齐到 `main`）。

--- a/src/components/ActivitySheet/ActivityQuadrant.vue
+++ b/src/components/ActivitySheet/ActivityQuadrant.vue
@@ -1,4 +1,4 @@
-<!-- 四象限壳：可编辑标题 + data-quadrant + 列表 slot -->
+<!-- 四象限壳：可编辑标题 + data-quadrant + 列表 slot；到期同步象限标签见 activityQuadrant.syncQuadrantTagsFromPrimaryDue -->
 <template>
   <div class="activity-quadrant" :data-quadrant="quadrantKey" :style="{ gridArea }">
     <div class="activity-quadrant__title">

--- a/src/components/ActivitySheet/ActivityQuadrant.vue
+++ b/src/components/ActivitySheet/ActivityQuadrant.vue
@@ -7,6 +7,9 @@
         class="activity-quadrant__title-readonly"
         :class="{ 'activity-quadrant__title-readonly--muted': !customTitle }"
         @dblclick="openTitleEdit"
+        @touchstart.passive="onTitleReadonlyTouchStart"
+        @touchend="onTitleReadonlyTouchEnd"
+        @touchcancel="onTitleReadonlyTouchCancel"
       >
         {{ titleShow }}
       </div>
@@ -35,6 +38,8 @@ import { NInput } from "naive-ui";
 import type { InputInst } from "naive-ui";
 import type { ActivityQuadrantKey } from "@/core/activityQuadrant";
 import { DEFAULT_KANBAN_QUADRANT_UI_LABELS } from "@/core/activityQuadrant";
+import { createTouchScheduledSingleAndDouble } from "@/composables/useTouchScheduledSingleAndDouble";
+import { useDevice } from "@/composables/useDevice";
 import { useSettingStore } from "@/stores/useSettingStore";
 
 const props = defineProps<{
@@ -43,8 +48,28 @@ const props = defineProps<{
 }>();
 
 const settingStore = useSettingStore();
+const { isMobile } = useDevice();
 const titleEditing = ref(false);
 const titleInputRef = ref<InputInst | null>(null);
+
+/** 移动端无 dblclick：双触窗口与 WeekPlanner / YearPlanner 一致 */
+const quadrantTitleTouch = createTouchScheduledSingleAndDouble<number>(() => {}, () => openTitleEdit());
+
+function onTitleReadonlyTouchStart(e: TouchEvent) {
+  if (!isMobile.value) return;
+  quadrantTitleTouch.touchStart(e);
+}
+
+function onTitleReadonlyTouchEnd(e: TouchEvent) {
+  if (!isMobile.value) return;
+  e.stopPropagation();
+  quadrantTitleTouch.touchEnd(0);
+}
+
+function onTitleReadonlyTouchCancel() {
+  if (!isMobile.value) return;
+  quadrantTitleTouch.touchCancel();
+}
 
 const customTitle = computed(() => settingStore.settings.kanbanQuadrantUi[props.quadrantKey]?.trim() ?? "");
 const titleShow = computed(() => customTitle.value || DEFAULT_KANBAN_QUADRANT_UI_LABELS[props.quadrantKey]);
@@ -89,8 +114,8 @@ function onTitleEnter() {
 
 .activity-quadrant__title-readonly {
   width: 100%;
-  min-height: 24px;
-  line-height: 24px;
+  min-height: 20px;
+  line-height: 20px;
   font-weight: 500;
   font-size: 12px;
   text-align: left;
@@ -106,7 +131,7 @@ function onTitleEnter() {
 .activity-quadrant__title-input {
   width: 100%;
   max-width: 100%;
-  height: 24px;
+  height: 22px;
 }
 
 .activity-quadrant__title-input :deep(.n-input__input-el) {

--- a/src/components/ActivitySheet/ActivityRow.vue
+++ b/src/components/ActivitySheet/ActivityRow.vue
@@ -259,7 +259,11 @@
     </div>
 
     <!-- tag显示 -->
-    <div v-if="item.tagIds && item.tagIds.length > 0 && showTagStrip" class="tag-content" :class="{ 'child-activity-tag': item.parentId }">
+    <div
+      v-if="item.tagIds && item.tagIds.length > 0 && tagSuffixIconHighlight && showTagStrip"
+      class="tag-content"
+      :class="{ 'child-activity-tag': item.parentId }"
+    >
       <TagRenderer
         :tag-ids="item.tagIds"
         :isCloseable="true"

--- a/src/components/ActivitySheet/ActivitySection.vue
+++ b/src/components/ActivitySheet/ActivitySection.vue
@@ -85,6 +85,20 @@
           <n-icon><TableDeleteColumn20Regular /></n-icon>
         </template>
       </n-button>
+      <!-- 移动端窄屏象限独奏：一键恢复四格 -->
+      <n-button
+        v-if="showExitQuadrantSoloButton"
+        large
+        type="default"
+        quaternary
+        class="section-button"
+        title="退出独奏"
+        @click="onExitQuadrantSoloClick"
+      >
+        <template #icon>
+          <n-icon><ChevronUpDown24Regular /></n-icon>
+        </template>
+      </n-button>
     </div>
 
     <div v-if="!headerOnly" ref="sectionScrollEl" class="section-content-container">
@@ -119,6 +133,7 @@ import {
   DocumentTableSearch24Regular,
   ColumnArrowRight20Regular,
   Grid24Regular,
+  ChevronUpDown24Regular,
   TableDeleteColumn20Regular,
   List24Filled,
   CalendarClock24Regular,
@@ -130,7 +145,12 @@ import { useSettingStore } from "@/stores/useSettingStore";
 import { useTagStore } from "@/stores/useTagStore";
 import { useActivityTagEditor } from "@/composables/useActivityTagEditor";
 import { useActivityDrag } from "@/composables/useActivityDrag";
-import { ACTIVITY_QUADRANT_DRAG_END_KEY, ACTIVITY_QUADRANT_SORT_KEY, type ActivitySectionSortKey } from "@/core/activityQuadrant";
+import {
+  ACTIVITY_QUADRANT_DRAG_END_KEY,
+  ACTIVITY_QUADRANT_SORT_KEY,
+  ACTIVITY_QUADRANT_SOLO_KEY,
+  type ActivitySectionSortKey,
+} from "@/core/activityQuadrant";
 import { useDevice } from "@/composables/useDevice";
 import ActivityRow, { activitySectionRowInjectKey } from "./ActivityRow.vue";
 import type { InputInst } from "naive-ui";
@@ -169,8 +189,21 @@ const searchInputRef = ref<InputInst | null>(null);
 const sectionScrollEl = ref<HTMLElement | null>(null);
 
 // ======================== Composables & Stores ========================
-const { isTouchSupported, isMobile } = useDevice();
+const { isTouchSupported, isMobile, width } = useDevice();
 const settingStore = useSettingStore();
+
+const quadrantSolo = inject(ACTIVITY_QUADRANT_SOLO_KEY, null);
+
+const showExitQuadrantSoloButton = computed(() => {
+  if (!props.headerOnly || !settingStore.settings.kanbanQuadrantMode) return false;
+  if (!isMobile.value || width.value > 650) return false;
+  if (!quadrantSolo) return false;
+  return quadrantSolo.soloQuadrantKey.value != null;
+});
+
+function onExitQuadrantSoloClick() {
+  quadrantSolo?.exitSolo();
+}
 const tagStore = useTagStore();
 const tagEditor = useActivityTagEditor();
 

--- a/src/components/ActivitySheet/ActivitySheet.vue
+++ b/src/components/ActivitySheet/ActivitySheet.vue
@@ -218,6 +218,7 @@ const {
 const { activityList } = storeToRefs(dataStore);
 const dateService = dataStore.dateService;
 const { isMobile, width } = useDevice();
+const settingStore = useSettingStore();
 
 /** 窄屏象限内输入聚焦时仅保留该格，腾出键盘可用高度；与样式断点 max-width:650px 一致 */
 const quadrantGridRef = ref<HTMLElement | null>(null);
@@ -377,9 +378,6 @@ const filterOptions = [
   { label: "预约活动", key: "schedule" },
   { label: "已删活动", key: "deleted" },
 ];
-
-// Kanban多个section参数管理
-const settingStore = useSettingStore();
 
 /** 象限模式下列头 + 四列表格共用排序 */
 const quadrantSharedSortKey = ref<ActivitySectionSortKey>("rank");

--- a/src/components/ActivitySheet/ActivitySheet.vue
+++ b/src/components/ActivitySheet/ActivitySheet.vue
@@ -190,6 +190,7 @@ import {
   findQuadrantKeyFromPoint,
   filterActivitiesForQuadrantKey,
   isActivityQuadrantKey,
+  syncQuadrantTagsFromPrimaryDue,
   type ActivityQuadrantKey,
   type ActivitySectionSortKey,
   type QuadrantDragEndPayload,
@@ -394,6 +395,35 @@ function handleQuadrantDragEnd(payload: QuadrantDragEndPayload) {
 provide(ACTIVITY_QUADRANT_DRAG_END_KEY, handleQuadrantDragEnd);
 provide(ACTIVITY_QUADRANT_SOLO_KEY, { soloQuadrantKey, exitSolo: exitQuadrantSolo });
 
+let quadrantDueUrgentInterval: ReturnType<typeof setInterval> | null = null;
+
+/** 四象限：按主到期日同步 urgent / Later（过期进 neither），口径与 ActivityRow + getCountdownClass 一致 */
+function runQuadrantDueUrgentSync() {
+  if (!settingStore.settings.kanbanQuadrantMode) return;
+  syncQuadrantTagsFromPrimaryDue(dataStore, activeActivities.value);
+}
+
+watch(
+  [activeActivities, () => settingStore.settings.kanbanQuadrantMode],
+  () => runQuadrantDueUrgentSync(),
+  { deep: true },
+);
+
+watch(
+  () => settingStore.settings.kanbanQuadrantMode,
+  (quad) => {
+    if (quadrantDueUrgentInterval) {
+      clearInterval(quadrantDueUrgentInterval);
+      quadrantDueUrgentInterval = null;
+    }
+    if (quad) {
+      runQuadrantDueUrgentSync();
+      quadrantDueUrgentInterval = setInterval(runQuadrantDueUrgentSync, 60_000);
+    }
+  },
+  { immediate: true },
+);
+
 onMounted(() => {
   if (settingStore.settings.kanbanSetting.length !== 6) {
     // 版本切换校正一次
@@ -406,6 +436,10 @@ onMounted(() => {
 
 onUnmounted(() => {
   cancelSoloQuadrantSync();
+  if (quadrantDueUrgentInterval) {
+    clearInterval(quadrantDueUrgentInterval);
+    quadrantDueUrgentInterval = null;
+  }
 });
 // 响应式可直接用
 const sections = computed(() => settingStore.settings.kanbanSetting.filter((s) => s.show));

--- a/src/components/ActivitySheet/ActivitySheet.vue
+++ b/src/components/ActivitySheet/ActivitySheet.vue
@@ -184,6 +184,7 @@ import ActivityQuadrant from "@/components/ActivitySheet/ActivityQuadrant.vue";
 import type { Activity, ActivitySectionConfig } from "@/core/types/Activity";
 import {
   ACTIVITY_QUADRANT_DRAG_END_KEY,
+  ACTIVITY_QUADRANT_SOLO_KEY,
   ACTIVITY_QUADRANT_SORT_KEY,
   applyQuadrantToActivity,
   findQuadrantKeyFromPoint,
@@ -248,6 +249,12 @@ function cancelSoloQuadrantSync() {
     clearTimeout(soloFocusSyncTimer);
     soloFocusSyncTimer = null;
   }
+}
+
+/** 窄屏象限：手动退出独奏（恢复四格同屏） */
+function exitQuadrantSolo() {
+  cancelSoloQuadrantSync();
+  soloQuadrantKey.value = null;
 }
 
 function syncSoloQuadrantFromActiveElement() {
@@ -385,6 +392,7 @@ function handleQuadrantDragEnd(payload: QuadrantDragEndPayload) {
 }
 
 provide(ACTIVITY_QUADRANT_DRAG_END_KEY, handleQuadrantDragEnd);
+provide(ACTIVITY_QUADRANT_SOLO_KEY, { soloQuadrantKey, exitSolo: exitQuadrantSolo });
 
 onMounted(() => {
   if (settingStore.settings.kanbanSetting.length !== 6) {
@@ -749,7 +757,7 @@ function getCountdownClass(dueDate: number | undefined | null): string {
   min-height: 0;
   display: grid;
   gap: 6px;
-  margin-bottom: 8px;
+  margin-bottom: calc(env(safe-area-inset-bottom, 12px) - 4px);
   margin-top: 2px;
   /* 勿在此层做 overflow-y: auto：窄屏 .right 已 overflow-y:hidden（见 HomeView），再嵌套纵滚会触发 iOS 异常 scrollExtent、无限条与灰带；靠 minmax(0,1fr) 压缩行 + 象限内 .section-content-container 滚动 */
   overflow: hidden;

--- a/src/components/PomotentionTimer/PomotentionTimer.vue
+++ b/src/components/PomotentionTimer/PomotentionTimer.vue
@@ -408,6 +408,6 @@ function handlePomoSeqRunning(status: boolean) {
   /* --phone-scale 由脚本按 visualViewport 宽高双轴写入 */
   transform: scale(var(--phone-scale, 1));
   transform-origin: center center;
-  padding-bottom: calc(env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
 }
 </style>

--- a/src/core/activityQuadrant.ts
+++ b/src/core/activityQuadrant.ts
@@ -39,6 +39,12 @@ export type QuadrantDragEndPayload = {
 /** ActivitySheet provide → ActivitySection inject，松手时尝试写入象限标签 */
 export const ACTIVITY_QUADRANT_DRAG_END_KEY: InjectionKey<(payload: QuadrantDragEndPayload) => void> = Symbol("activityQuadrantDragEnd");
 
+/** ActivitySheet provide → 列头退出窄屏「独奏」仅显示一格 */
+export const ACTIVITY_QUADRANT_SOLO_KEY: InjectionKey<{
+  soloQuadrantKey: Ref<ActivityQuadrantKey | null>;
+  exitSolo: () => void;
+}> = Symbol("activityQuadrantSolo");
+
 export function getActivityQuadrantKey(activity: Activity): ActivityQuadrantKey {
   const ids = activity.tagIds ?? [];
   const hasU = ids.includes(TAG_ID_URGENT);

--- a/src/core/activityQuadrant.ts
+++ b/src/core/activityQuadrant.ts
@@ -6,6 +6,8 @@ import type { Activity } from "@/core/types/Activity";
 import type { useDataStore } from "@/stores/useDataStore";
 import { TAG_ID_IMPORTANT, TAG_ID_URGENT } from "@/core/constants";
 
+type DataStore = ReturnType<typeof useDataStore>;
+
 export type ActivityQuadrantKey = "urgentImportant" | "importantOnly" | "urgentOnly" | "neither";
 
 /** 与 ActivitySection 排序下拉一致，象限模式四格共享同一排序态 */
@@ -59,7 +61,64 @@ export function filterActivitiesForQuadrantKey(pool: Activity[], key: ActivityQu
   return pool.filter((a) => getActivityQuadrantKey(a) === key);
 }
 
-type DataStore = ReturnType<typeof useDataStore>;
+/** 与 ActivityRow 日期列 + ActivitySheet.getCountdownClass 一致：待办看 dueDate，日程看 dueRange[0] */
+export function getActivityPrimaryDueMs(activity: Activity): number | null {
+  if (activity.class === "T") {
+    const d = activity.dueDate;
+    return d != null && d !== 0 ? d : null;
+  }
+  const r = activity.dueRange?.[0];
+  return r != null && r !== 0 ? r : null;
+}
+
+type DueDayBucket = "none" | "past" | "today" | "future";
+
+function dueDayBucket(dueMs: number | null): DueDayBucket {
+  if (dueMs == null) return "none";
+  const now = new Date();
+  const due = new Date(dueMs);
+  due.setHours(0, 0, 0, 0);
+  const diff = Math.ceil((due.getTime() - now.setHours(0, 0, 0, 0)) / 86400000);
+  if (diff === 0) return "today";
+  if (diff < 0) return "past";
+  return "future";
+}
+
+const quadrantDueDayPrev = new Map<number, DueDayBucket>();
+
+/**
+ * 四象限模式：按主到期日与 ActivitySheet.getCountdownClass 同源口径同步象限标签。
+ * - 到期日从非今天变为今天：追加 TAG_ID_URGENT（85）；用户当日手动去掉 urgent 后不会反复补回。
+ * - 主到期已过期（diff&lt;0，即 countdown-boom）：若有 urgent/important，则写入 Later（去掉 85、126）；手动改日期同样会触发。
+ */
+export function syncQuadrantTagsFromPrimaryDue(store: DataStore, activities: readonly Activity[]): void {
+  const seen = new Set<number>();
+
+  for (const a of activities) {
+    if (a.deleted || a.status === "cancelled" || a.isUntaetigkeit) continue;
+
+    seen.add(a.id);
+    const dueMs = getActivityPrimaryDueMs(a);
+    const bucket = dueDayBucket(dueMs);
+    const before = quadrantDueDayPrev.get(a.id);
+
+    if (bucket === "past") {
+      const ids = a.tagIds ?? [];
+      if (ids.includes(TAG_ID_URGENT) || ids.includes(TAG_ID_IMPORTANT)) {
+        applyQuadrantToActivity(store, a.id, "neither");
+      }
+    } else if (bucket === "today" && before !== "today" && !(a.tagIds?.includes(TAG_ID_URGENT))) {
+      const next = [...(a.tagIds ?? []), TAG_ID_URGENT];
+      store.setActivityTags(a.id, next);
+    }
+
+    quadrantDueDayPrev.set(a.id, bucket);
+  }
+
+  for (const id of quadrantDueDayPrev.keys()) {
+    if (!seen.has(id)) quadrantDueDayPrev.delete(id);
+  }
+}
 
 export function applyQuadrantToActivity(store: DataStore, activityId: number, targetKey: ActivityQuadrantKey): void {
   const activity = store.activityById.get(activityId);

--- a/src/core/activityQuadrant.ts
+++ b/src/core/activityQuadrant.ts
@@ -90,6 +90,7 @@ const quadrantDueDayPrev = new Map<number, DueDayBucket>();
  * 四象限模式：按主到期日与 ActivitySheet.getCountdownClass 同源口径同步象限标签。
  * 凡改动 tagIds 均经 dataStore.setActivityTags / applyQuadrantToActivity，与 store 内 lastModified、synced、持久化、防抖上传一致。
  * - 到期日从非今天变为今天：追加 TAG_ID_URGENT（85）；用户当日手动去掉 urgent 后不会反复补回。
+ * - 到期日从当天改为未来或清空主到期：去掉 TAG_ID_URGENT（保留 126）；与「当天→过期」整组进 Later 分支区分。
  * - 主到期已过期（diff&lt;0，即 countdown-boom）：若有 urgent/important，则写入 Later（去掉 85、126）；手动改日期同样会触发。
  */
 export function syncQuadrantTagsFromPrimaryDue(store: DataStore, activities: readonly Activity[]): void {
@@ -107,6 +108,13 @@ export function syncQuadrantTagsFromPrimaryDue(store: DataStore, activities: rea
       const ids = a.tagIds ?? [];
       if (ids.includes(TAG_ID_URGENT) || ids.includes(TAG_ID_IMPORTANT)) {
         applyQuadrantToActivity(store, a.id, "neither");
+      }
+    } else if (before === "today" && (bucket === "future" || bucket === "none")) {
+      // 主到期离开「当天」落到未来或无日期：撤销 urgent（日程 S 改约时常用）
+      const ids = a.tagIds ?? [];
+      if (ids.includes(TAG_ID_URGENT)) {
+        const next = ids.filter((id) => id !== TAG_ID_URGENT);
+        store.setActivityTags(a.id, next.length ? next : []);
       }
     } else if (bucket === "today" && before !== "today" && !(a.tagIds?.includes(TAG_ID_URGENT))) {
       const next = [...(a.tagIds ?? []), TAG_ID_URGENT];

--- a/src/core/activityQuadrant.ts
+++ b/src/core/activityQuadrant.ts
@@ -88,6 +88,7 @@ const quadrantDueDayPrev = new Map<number, DueDayBucket>();
 
 /**
  * 四象限模式：按主到期日与 ActivitySheet.getCountdownClass 同源口径同步象限标签。
+ * 凡改动 tagIds 均经 dataStore.setActivityTags / applyQuadrantToActivity，与 store 内 lastModified、synced、持久化、防抖上传一致。
  * - 到期日从非今天变为今天：追加 TAG_ID_URGENT（85）；用户当日手动去掉 urgent 后不会反复补回。
  * - 主到期已过期（diff&lt;0，即 countdown-boom）：若有 urgent/important，则写入 Later（去掉 85、126）；手动改日期同样会触发。
  */
@@ -120,6 +121,7 @@ export function syncQuadrantTagsFromPrimaryDue(store: DataStore, activities: rea
   }
 }
 
+/** 松手投放象限：仅通过 store.setActivityTags 写标签，保证云端待同步元数据与拖动路径一致 */
 export function applyQuadrantToActivity(store: DataStore, activityId: number, targetKey: ActivityQuadrantKey): void {
   const activity = store.activityById.get(activityId);
   if (!activity || activity.deleted) return;

--- a/src/stores/useDataStore.ts
+++ b/src/stores/useDataStore.ts
@@ -778,17 +778,6 @@ export const useDataStore = defineStore(
       scheduleDebouncedCloudUpload();
     }
 
-    /**
-     * 标记整条 Activity 待云端同步（含 tagIds 与其它字段）。象限拖动 / 日期推导改 tag 最终均经 setActivityTags，与此同源。
-     */
-    function touchActivityCloudSync(activityId: number): boolean {
-      const activity = activityById.value.get(activityId);
-      if (!activity) return false;
-      applyActivityCloudDirty(activity);
-      persistActivityListForCloud();
-      return true;
-    }
-
     function setActivityTags(activityId: number, newTagIds: number[]) {
       const activity = activityById.value.get(activityId);
       if (!activity) return false;
@@ -1089,7 +1078,6 @@ export const useDataStore = defineStore(
       addTagToActivity,
       removeTagFromActivity,
       setActivityTags,
-      touchActivityCloudSync,
       toggleActivityTag,
       createAndAddTagToActivity,
       getActivityTags,

--- a/src/stores/useDataStore.ts
+++ b/src/stores/useDataStore.ts
@@ -768,16 +768,34 @@ export const useDataStore = defineStore(
       );
     }
 
+    function applyActivityCloudDirty(activity: Activity): void {
+      activity.lastModified = Date.now();
+      activity.synced = false;
+    }
+
+    function persistActivityListForCloud(): void {
+      saveActivities(activityList.value);
+      scheduleDebouncedCloudUpload();
+    }
+
+    /**
+     * 标记整条 Activity 待云端同步（含 tagIds 与其它字段）。象限拖动 / 日期推导改 tag 最终均经 setActivityTags，与此同源。
+     */
+    function touchActivityCloudSync(activityId: number): boolean {
+      const activity = activityById.value.get(activityId);
+      if (!activity) return false;
+      applyActivityCloudDirty(activity);
+      persistActivityListForCloud();
+      return true;
+    }
+
     function setActivityTags(activityId: number, newTagIds: number[]) {
       const activity = activityById.value.get(activityId);
       if (!activity) return false;
 
       activity.tagIds = newTagIds.length > 0 ? newTagIds : undefined;
-      activity.lastModified = Date.now();
-      activity.synced = false;
-
-      saveActivities(activityList.value);
-      scheduleDebouncedCloudUpload();
+      applyActivityCloudDirty(activity);
+      persistActivityListForCloud();
 
       // 标签被实际应用到 Activity 时，更新本地 tag 的 lastUsed（不单独 saveTags；activity 已标记 unsynced 并由上方防抖上传覆盖）
       tagStore.touchTagsLastUsed(newTagIds);
@@ -1071,6 +1089,7 @@ export const useDataStore = defineStore(
       addTagToActivity,
       removeTagFromActivity,
       setActivityTags,
+      touchActivityCloudSync,
       toggleActivityTag,
       createAndAddTagToActivity,
       getActivityTags,


### PR DESCRIPTION
- urgent由日期触发
- UI调整
- tag加入同步机制

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches four-quadrant tagging logic and activity tag persistence/sync, which could misclassify tags or trigger unexpected cloud updates if edge cases are missed.
> 
> **Overview**
> **Four-quadrant mode v2:** adds automatic syncing of quadrant semantics to tags based on an activity’s *primary due date* (auto-add `urgent` when due becomes today, remove it when leaving today, and clear urgent/important when overdue), wired into `ActivitySheet` via watchers plus a 1‑minute interval while quadrant mode is enabled.
> 
> **Mobile UX improvements:** introduces a narrow-screen “quadrant solo” mode with a header button to exit back to the 4-grid view, and adds touch-based double-tap editing for quadrant titles (since `dblclick` is unreliable on mobile). Also tightens tag strip display to only show when the tag icon indicates visible tags, and adjusts safe-area padding/margins in quadrant grid and the Pomodoro phone layout.
> 
> **Data sync changes:** refactors `useDataStore.setActivityTags` to share helpers for marking activities dirty and persisting/scheduling cloud upload, and exposes a new `touchActivityCloudSync` utility for forcing an activity to be marked for sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38bebd3d2394650aac6314c477bdb5f562000014. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->