### PR TITLE
v0.6.9 bug 修补

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pomotention"
-version = "0.6.9
+version = "0.6.9"
 description = "A focus enhancement software to help you stay present and love yourself"
 authors = ["xeonilian"]
 edition = "2021"

--- a/src/__tests__/chartDataService.test.ts
+++ b/src/__tests__/chartDataService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { collectPomodoroData, collectTaskRecordData, aggregateByTime } from "@/services/chartDataService";
+import { collectPomodoroData, collectTaskRecordData, aggregateByTime } from "@/services/chart/chartDataService";
 import { METRICS } from "@/core/types/Metrics";
+import type { DataPoint } from "@/core/types/Chart";
 import type { Todo } from "@/core/types/Todo";
 import type { Task } from "@/core/types/Task";
 
@@ -206,8 +207,8 @@ describe("chartDataService", () => {
 
       const result = collectTaskRecordData(tasks as Task[]);
 
-      const externalInterruptions = result.filter((p) => p.metric === METRICS.INTERRUPTION_EXTERNAL);
-      const internalInterruptions = result.filter((p) => p.metric === METRICS.INTERRUPTION_INTERNAL);
+      const externalInterruptions = result.filter((p: DataPoint) => p.metric === METRICS.INTERRUPTION_EXTERNAL);
+      const internalInterruptions = result.filter((p: DataPoint) => p.metric === METRICS.INTERRUPTION_INTERNAL);
 
       // 验证分类
       expect(externalInterruptions).toHaveLength(2);

--- a/src/components/PomotentionTimer/PomodoroSequence.vue
+++ b/src/components/PomotentionTimer/PomodoroSequence.vue
@@ -149,7 +149,12 @@ import { SoundType } from "@/core/sounds.ts";
 type PomodoroStep = {
   type: "work" | "break";
   duration: number;
+  unit?: "min" | "sec";
 };
+
+function stepDurationSec(step: PomodoroStep): number {
+  return step.unit === "sec" ? step.duration : step.duration * 60;
+}
 
 const timerStore = useTimerStore();
 const settingStore = useSettingStore();
@@ -169,8 +174,9 @@ function normalizeSequenceForDisplay(sequence: string): string {
   const trimmed = sequence.trim();
   if (/^HIITs?\s*=/i.test(trimmed)) return trimmed;
 
+  let body = trimmed.replace(/^>{4}/, "").replace(/^<{4}/, "").trim();
   const defaultWorkDuration = getDefaultWorkDurationMinutes();
-  return sequence.replace(/w(\d+)/gi, (_, rawDuration: string) => {
+  body = body.replace(/w(\d+)/gi, (_, rawDuration: string) => {
     const explicitWorkDuration = Number.parseInt(rawDuration, 10);
     if (!Number.isFinite(explicitWorkDuration) || explicitWorkDuration < 1 || explicitWorkDuration > 60) {
       return "🍅";
@@ -180,6 +186,8 @@ function normalizeSequenceForDisplay(sequence: string): string {
     }
     return `🍅${explicitWorkDuration}`;
   });
+  if (!body) return defaultPomoSequenceTemplate();
+  return `>>>>${body}`;
 }
 
 function parseExplicitWorkDuration(token: string): number {
@@ -198,7 +206,7 @@ const breakDurationPad = computed(() => settingStore.settings.durations.breakDur
 
 function defaultPomoSequenceTemplate(): string {
   const bd = breakDurationPad.value;
-  return `<<<<🍅+${bd}`;
+  return `>>>>🍅+${bd}`;
 }
 
 function defaultHiitSequenceTemplate(): string {
@@ -211,7 +219,8 @@ function isValidHiitSequence(val: string): boolean {
 }
 
 function isValidPomoSequence(val: string): boolean {
-  return val.trim().startsWith("<<<<");
+  const trimmed = val.trim();
+  return trimmed.startsWith(">>>>") || trimmed.startsWith("<<<<");
 }
 
 function loadSequenceForMode(mode: "pomo" | "hiit"): string {
@@ -349,16 +358,17 @@ watch(
   },
 );
 
-// 解析序列
-function parseSequence(sequence: string): PomodoroStep[] {
+// 解析番茄序列（分钟）
+function parsePomoSequence(sequence: string): PomodoroStep[] {
   const validBreakTimes = ["01", "02", "05", "10", "15", "30", "60"];
-  const firstStepMatch = sequence.match(/🍅\d*|w\d+|\d+/i);
+  let seq = sequence.trim().replace(/^>{4}/, "").replace(/^<{4}/, "").trim();
+  const firstStepMatch = seq.match(/🍅\d*|w\d+|\d+/i);
   if (!firstStepMatch) return [];
 
   const firstStepIndex = firstStepMatch.index || 0;
-  sequence = sequence.substring(firstStepIndex);
+  seq = seq.substring(firstStepIndex);
 
-  const steps = sequence.split("+").map((step) => step.trim());
+  const steps = seq.split("+").map((step) => step.trim());
   return steps.map((step) => {
     if (/^🍅\d+$/u.test(step)) {
       return { type: "work", duration: parseExplicitWorkDuration(step.slice(2)) };
@@ -374,6 +384,47 @@ function parseSequence(sequence: string): PomodoroStep[] {
       return { type: "break", duration: parseInt(breakTime) };
     }
   });
+}
+
+function parseHiitSequence(sequence: string): PomodoroStep[] {
+  const match = sequence.trim().match(/^HIITs?\s*=\s*(.+)$/i);
+  if (!match) return [];
+
+  const steps: PomodoroStep[] = [];
+  HIIT_BLOCK_IN_SEQ_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HIIT_BLOCK_IN_SEQ_RE.exec(match[1])) !== null) {
+    const workSec = Number.parseInt(m[1], 10);
+    const breakSec = Number.parseInt(m[2], 10);
+    const reps = Number.parseInt(m[3], 10);
+    if (
+      !Number.isFinite(workSec) ||
+      workSec < 1 ||
+      !Number.isFinite(breakSec) ||
+      breakSec < 1 ||
+      !Number.isFinite(reps) ||
+      reps < 1
+    ) {
+      throw new Error(`Invalid HIIT block: (${m[1]}+${m[2]})x${m[3]}`);
+    }
+    for (let i = 0; i < reps; i++) {
+      steps.push({ type: "work", duration: workSec, unit: "sec" });
+      steps.push({ type: "break", duration: breakSec, unit: "sec" });
+    }
+  }
+  if (steps.length === 0) {
+    throw new Error(`Invalid HIIT sequence. Expected format: HIITs=(work+break)xrepeat`);
+  }
+  return steps;
+}
+
+// 解析序列（番茄或 HIIT）
+function parseSequence(sequence: string): PomodoroStep[] {
+  const trimmed = sequence.trim();
+  if (/^HIITs?\s*=/i.test(trimmed)) {
+    return parseHiitSequence(trimmed);
+  }
+  return parsePomoSequence(trimmed);
 }
 
 /** 冷启动或 store finalize 无 phase 回调时，由 sequencePhaseContinuation 推进序列 */
@@ -442,6 +493,7 @@ function runStep(steps: PomodoroStep[]): void {
   }
 
   const step = steps[currentStep.value];
+  const suppressEndCue = step.unit === "sec" && currentStep.value < steps.length - 1;
 
   const onFinish = () => {
     // 与 isRunning 对齐：用户点停止时 cancelTimer 已把 store 置 idle，此处应直接返回；若仅本地 isRunning 失步而计时仍在，仍须推进到 runStep/stopPomodoro（以番茄收尾时自然结束与手动 Stop 一致）
@@ -461,13 +513,20 @@ function runStep(steps: PomodoroStep[]): void {
 
   if (step.type === "work") {
     statusLabel.value = `🍅 ${currentPomodoro.value}/${totalPomodoros.value}`;
-    timerStore.startWorking(step.duration, () => {
-      currentPomodoro.value++;
-      onFinish();
-    });
+    const unit = step.unit ?? "min";
+    timerStore.startWorking(
+      step.duration,
+      () => {
+        currentPomodoro.value++;
+        onFinish();
+      },
+      unit,
+      suppressEndCue,
+    );
   } else {
-    statusLabel.value = `Break ${step.duration}min`;
-    timerStore.startBreak(step.duration, onFinish);
+    const unit = step.unit ?? "min";
+    statusLabel.value = unit === "sec" ? `Break ${step.duration}s` : `Break ${step.duration}min`;
+    timerStore.startBreak(step.duration, onFinish, unit, suppressEndCue);
   }
 }
 
@@ -520,11 +579,19 @@ function addHiitBlock(): void {
   }
 }
 
+function ensurePomoSequencePrefix(val: string): string {
+  const trimmed = val.trim();
+  if (/^HIITs?\s*=/i.test(trimmed)) return trimmed;
+  if (isValidPomoSequence(trimmed)) return normalizeSequenceForDisplay(trimmed);
+  return `>>>>${trimmed}`;
+}
+
 function addPomodoro(): void {
+  const bd = breakDurationPad.value;
   if (sequenceInput.value.trim() === "") {
-    sequenceInput.value = "🍅" + settingStore.settings.durations.breakDuration.toString().padStart(2, "0");
+    sequenceInput.value = `>>>>🍅+${bd}`;
   } else {
-    sequenceInput.value += "+🍅+" + settingStore.settings.durations.breakDuration.toString().padStart(2, "0");
+    sequenceInput.value = `${ensurePomoSequencePrefix(sequenceInput.value)}+🍅+${bd}`;
   }
 }
 
@@ -532,18 +599,18 @@ function addPomodoro(): void {
 const progressContainer = ref<HTMLElement | null>(null);
 
 // 创建时间块函数（用 flex 比例适配手机窄屏，不写死 px 宽度）
-function createTimeBlock(duration: number, type: string, sequenceStr: string): HTMLElement {
+function createTimeBlock(step: PomodoroStep, sequenceStr: string): HTMLElement {
   const block = document.createElement("div");
   block.className = "time-block";
-  const totalDuration = parseSequence(sequenceStr).reduce((sum, step) => sum + step.duration, 0);
-  const flexGrow = totalDuration > 0 ? duration / totalDuration : 0;
+  const totalDuration = parseSequence(sequenceStr).reduce((sum, s) => sum + stepDurationSec(s), 0);
+  const flexGrow = totalDuration > 0 ? stepDurationSec(step) / totalDuration : 0;
   block.style.flexGrow = String(flexGrow);
   block.style.flexShrink = String(flexGrow);
   block.style.flexBasis = "0";
   block.style.height = "20px";
   block.style.margin = "0.5px";
   block.style.borderRadius = "2px";
-  block.classList.add(type);
+  block.classList.add(step.type);
   return block;
 }
 
@@ -568,7 +635,7 @@ function resolveActiveStepIndex(): number {
     expectedType &&
     steps[baseIndex] &&
     steps[baseIndex].type === expectedType &&
-    steps[baseIndex].duration * 60 === expectedDurationSec
+    stepDurationSec(steps[baseIndex]) === expectedDurationSec
   ) {
     return baseIndex;
   }
@@ -577,8 +644,9 @@ function resolveActiveStepIndex(): number {
     for (let offset = 0; offset < steps.length; offset++) {
       const left = baseIndex - offset;
       const right = baseIndex + offset;
-      if (left >= 0 && steps[left].type === expectedType && steps[left].duration * 60 === expectedDurationSec) return left;
-      if (right < steps.length && steps[right].type === expectedType && steps[right].duration * 60 === expectedDurationSec) return right;
+      if (left >= 0 && steps[left].type === expectedType && stepDurationSec(steps[left]) === expectedDurationSec) return left;
+      if (right < steps.length && steps[right].type === expectedType && stepDurationSec(steps[right]) === expectedDurationSec)
+        return right;
     }
   }
 
@@ -647,7 +715,7 @@ function initializeProgress(sequence: string): void {
   // console.log("Steps for progress:", steps);
 
   steps.forEach((step) => {
-    const block = createTimeBlock(step.duration, step.type, sequence);
+    const block = createTimeBlock(step, sequence);
     block.classList.add(step.type);
     progressContainer.value?.appendChild(block);
   });

--- a/src/composables/sync/index.ts
+++ b/src/composables/sync/index.ts
@@ -2,4 +2,4 @@
 export { useSyncWidget } from "@/composables/sync/useSyncWidget";
 export { useRelativeTime } from "@/composables/sync/useRelativeTime";
 export { useDataExport } from "@/composables/sync/useDataExport";
-export { useMigrate } from "@/composables/sync/useMigrate";
+export { initialMigrate } from "@/composables/sync/useMigrate";

--- a/src/stores/useSettingStore.ts
+++ b/src/stores/useSettingStore.ts
@@ -121,7 +121,7 @@ const defaultSettings: GlobalSettings = {
   viewSet: "day",
   marquee: "", // 保持觉察 🍅 = ⏰ + 🎯 + 👁‍🗨
   pomodoroStateMessage: undefined, // 自定义番茄钟状态消息，未设置时使用默认逻辑
-  pomoSequenceInput: "<<<<🍅+05+🍅+05+🍅+05+🍅+15", // 序列模式默认输入
+  pomoSequenceInput: ">>>>🍅+05+🍅+05+🍅+05+🍅+15", // 序列模式默认输入
   pomoSeqInsertMode: "pomo",
   pomoSeqHiitPreset: "(40+20)x12",
   pomoSeqHiitInput: "HIITs=(40+20)x12",

--- a/src/stores/useTimerStore.ts
+++ b/src/stores/useTimerStore.ts
@@ -38,6 +38,8 @@ export const useTimerStore = defineStore(
     const finalizedForPhase = ref(false);
     /** 阶段结束回调（无法持久化，刷新后丢失） */
     const phaseFinishCallback = ref<(() => void) | null>(null);
+    /** 当前 phase 自然结束时是否跳过 WORK_END / BREAK_END（HIIT 中间交替） */
+    const suppressPhaseEndCueForPhase = ref(false);
 
     const settingStore = useSettingStore();
     const breakDuration = ref(settingStore.settings.durations.breakDuration);
@@ -272,7 +274,11 @@ export const useTimerStore = defineStore(
             resetTimer();
           }
         };
-        void playPhaseEndCue(SoundType.WORK_END).finally(() => runAfterWorkEndCue());
+        if (suppressPhaseEndCueForPhase.value) {
+          runAfterWorkEndCue();
+        } else {
+          void playPhaseEndCue(SoundType.WORK_END).finally(() => runAfterWorkEndCue());
+        }
       } else if (pomodoroState.value === "breaking") {
         const stripWnBeforeChain = !settingStore.settings.isWhiteNoiseEnabled;
         const runAfterBreakEndCue = () => {
@@ -286,7 +292,11 @@ export const useTimerStore = defineStore(
             resetTimer();
           }
         };
-        void playPhaseEndCue(SoundType.BREAK_END).finally(() => runAfterBreakEndCue());
+        if (suppressPhaseEndCueForPhase.value) {
+          runAfterBreakEndCue();
+        } else {
+          void playPhaseEndCue(SoundType.BREAK_END).finally(() => runAfterBreakEndCue());
+        }
       }
     }
 
@@ -389,12 +399,13 @@ export const useTimerStore = defineStore(
       finalizeCurrentPhase();
     }
 
-    function startWorking(duration: number, onFinish?: () => void): void {
+    function startWorking(duration: number, onFinish?: () => void, unit: "min" | "sec" = "min", suppressPhaseEndCue = false): void {
+      suppressPhaseEndCueForPhase.value = suppressPhaseEndCue;
       beginNewPhase(onFinish);
 
       pomodoroState.value = "working";
       const dur = duration ?? settingStore.settings.durations.workDuration;
-      totalTime.value = dur * 60;
+      totalTime.value = unit === "sec" ? dur : dur * 60;
       timeRemaining.value = totalTime.value;
       startTime.value = Date.now();
       phaseEndsAt.value = startTime.value + totalTime.value * 1000;
@@ -413,14 +424,15 @@ export const useTimerStore = defineStore(
     /** 上一 tick 的已过秒数，用于「边界跨越」检测；息屏/后台时墙钟会跳秒，不能用 |elapsed-node|<=1 */
     const breakReminderPrevElapsed = ref(-1);
 
-    function startBreak(duration: number, onFinish?: () => void): void {
-      breakReminderCount.value = duration;
+    function startBreak(duration: number, onFinish?: () => void, unit: "min" | "sec" = "min", suppressPhaseEndCue = false): void {
+      suppressPhaseEndCueForPhase.value = suppressPhaseEndCue;
+      breakReminderCount.value = unit === "sec" ? 1 : duration;
       breakReminderPrevElapsed.value = -1;
       beginNewPhase(onFinish);
 
       pomodoroState.value = "breaking";
       const dur = duration ?? breakDuration.value;
-      totalTime.value = dur * 60;
+      totalTime.value = unit === "sec" ? dur : dur * 60;
       timeRemaining.value = totalTime.value;
       startTime.value = Date.now();
       phaseEndsAt.value = startTime.value + totalTime.value * 1000;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1261,7 +1261,7 @@ function onUncancelTodo(id: number) {
 
 /** 移动端 FAB：回到当下（日期/日视图 + 清筛选；onDateSet('today') 已清选中） */
 function onMobileFabResetToPresent() {
-  dataStore.clearFilterTags();
+  dataStore.clearActivityFilters();
   settingStore.settings.viewSet = "day";
   onDateSet("today");
   settingStore.settings.topHeight = isMobile.value ? 305 : 300;


### PR DESCRIPTION
- HIITs 识别错误
- HIIT前缀识别错误
- 回到当下清楚星标

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timer store and PomodoroSequence parsing/playback behavior changed for HIIT and legacy sequence strings; incorrect edge cases could mis-run sequences or skip cues.
> 
> **Overview**
> **v0.6.9** 修补番茄序列与 HIIT、移动端「回到当下」筛选，并修正 Tauri 版本号引号。
> 
> 番茄序列前缀从 `<<<<` 改为 `>>>>`（仍接受旧 `<<<<`），解析拆成 `parsePomoSequence` / `parseHiitSequence`，`HIITs=(work+break)xrepeat` 按**秒**跑序列；进度条与当前步对齐改用 `stepDurationSec`。`useTimerStore` 的 `startWorking` / `startBreak` 支持 `min`/`sec` 与 `suppressPhaseEndCue`，HIIT 中间段不再反复播 WORK_END/BREAK_END。
> 
> 移动端 FAB「回到当下」改为 `clearActivityFilters()`，会同时清标签筛选和星标筛选。另：`chartDataService` 测试改导入路径；同步 barrel 导出 `initialMigrate` 替代 `useMigrate`。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dafdaae02a2c864f21de83896ff41d9ed23b6b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->