### PR TITLE
调整颜色 + 修复录入分号

### DIFF
--- a/src/__tests__/parseLedgerSegments.test.ts
+++ b/src/__tests__/parseLedgerSegments.test.ts
@@ -34,8 +34,9 @@ describe("parseLedgerFromTitle v1", () => {
   it("收入与支出 + 分号分段", () => {
     const r = parseLedgerFromTitle("奖金 +5000; 午饭 -30￥");
     expect(r.ok).toHaveLength(2);
-    expect(r.ok[0]).toMatchObject({ amount: 5000, direction: "income", memo: "午饭" });
-    expect(r.ok[1]).toMatchObject({ amount: 30, direction: "expense" });
+    expect(r.ok[0]).toMatchObject({ amount: 5000, direction: "income" });
+    expect(r.ok[0].memo).toBeUndefined();
+    expect(r.ok[1]).toMatchObject({ amount: 30, direction: "expense", memo: "午饭" });
     expect(r.diaryText).toBe("奖金 午饭");
   });
 

--- a/src/components/Ledger/LedgerAggregatePopover.vue
+++ b/src/components/Ledger/LedgerAggregatePopover.vue
@@ -76,9 +76,6 @@
                   {{ row.direction === "income" ? "+" : "-" }}{{ formatLedgerMoneyFixed(row.amount) }}
                 </td>
               </tr>
-              <tr v-if="aggregateData.tableRows.length === 0">
-                <td colspan="4" class="ledger-aggregate-table__empty">暂无记账</td>
-              </tr>
             </tbody>
           </table>
         </div>
@@ -262,7 +259,7 @@ watch(
 }
 
 .ledger-aggregate-table th,
-.ledger-aggregate-table td:not(.ledger-aggregate-table__empty) {
+.ledger-aggregate-table td {
   width: 25%;
   padding: 5px 8px;
   text-align: left;
@@ -295,13 +292,6 @@ watch(
   background: var(--n-color-modal);
   color: var(--color-text-secondary);
   font-weight: 500;
-}
-
-.ledger-aggregate-table__empty {
-  text-align: center;
-  color: var(--color-text-secondary);
-  padding: 24px 8px;
-  border-bottom: 1px solid var(--n-border-color);
 }
 
 .ledger-income {

--- a/src/components/Ledger/LedgerMiniChart.vue
+++ b/src/components/Ledger/LedgerMiniChart.vue
@@ -47,11 +47,15 @@ function resolveChartColor(cssVar: string, fallback: string): string {
   return raw || fallback;
 }
 
+function resolveEmptyLabelColor(): string {
+  return resolveChartColor("--color-text-secondary", EMPTY_TEXT_FALLBACK);
+}
+
 function buildPieOption(): EChartsOption {
   const hasData = props.pieSlices.length > 0;
   if (!hasData) {
     const ringColor = resolveChartColor("--color-background-light", EMPTY_RING_FALLBACK);
-    const textColor = resolveChartColor("--color-background-light", EMPTY_TEXT_FALLBACK);
+    const textColor = resolveEmptyLabelColor();
     return {
       tooltip: { show: false },
       series: [
@@ -96,7 +100,7 @@ function buildTrendOption(): EChartsOption {
   return {
     tooltip: { trigger: "axis" },
     legend: { top: 0, right: 0, itemWidth: 10, itemHeight: 10, textStyle: { fontSize: 11 } },
-    grid: { left: 40, right: 12, top: 28, bottom: 12 },
+    grid: { left: 24, right: 12, top: 28, bottom: 12 },
     xAxis: {
       type: "category",
       data: buckets.map((b) => b.label),
@@ -130,20 +134,6 @@ function buildTrendOption(): EChartsOption {
         itemStyle: { color: "#18a058" },
       },
     ],
-    graphic: hasData
-      ? undefined
-      : [
-          {
-            type: "text",
-            left: "center",
-            top: "middle",
-            style: {
-              text: props.emptyLabel,
-              fill: resolveChartColor("--color-background-light", EMPTY_TEXT_FALLBACK),
-              fontSize: 12,
-            },
-          },
-        ],
   };
 }
 

--- a/src/components/MonthPlanner/MonthPlanner.vue
+++ b/src/components/MonthPlanner/MonthPlanner.vue
@@ -32,7 +32,7 @@
             <div
               class="date-badge"
               :class="{
-                today: day.isToday && !props.showStatsOnly,
+                today: day.isToday,
                 'date-badge--stats': props.showStatsOnly && day.isCurrentMonth,
               }"
               @click.stop="() => handleDateSelectDayView(day.startTs)"
@@ -126,6 +126,25 @@ const props = withDefaults(
 
 const dayNames = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
 const STANDARD_POMO = 20;
+/** 统计模式整格底色终点 alpha（20 番茄时） */
+const STATS_POMO_BG_MAX_ALPHA = 0.45;
+
+/** 低段抬升：2 番茄 ≈ 旧算法 6 番茄，20 番茄仍拉满 ratio */
+function mapPomoCountToColorRatio(count: number): number {
+  if (count <= 0) return 0;
+  const n = Math.min(count, STANDARD_POMO);
+  if (n === 1) return 0.25;
+  if (n === 2) return 0.3;
+  return 0.3 + ((n - 2) / (STANDARD_POMO - 2)) * 0.7;
+}
+
+/** 低段 alpha 与旧算法一致（2 番茄对齐旧 6），高段拉向 STATS_POMO_BG_MAX_ALPHA */
+function mapStatsPomoAlphaRatio(colorRatio: number): number {
+  const r = Math.min(1, Math.max(0, colorRatio));
+  if (r <= 0) return 0;
+  if (r <= 0.3) return (r / 0.3) * 0.2;
+  return 0.2 + ((r - 0.3) / 0.7) * 0.8;
+}
 
 type UnifiedItem = {
   key: string;
@@ -286,7 +305,7 @@ const days = computed(() => {
 
     const sumWorkMs = bucket.filter((i) => i.type === "todo").reduce((sum, item) => sum + calcTodoWorkMs(item as unknown as Todo), 0);
 
-    const ratio = Math.min(sumRealPomo / STANDARD_POMO, 1);
+    const ratio = mapPomoCountToColorRatio(sumRealPomo);
 
     return {
       index: idx,
@@ -402,9 +421,23 @@ function getDayCardStyle(ratio: number, isCurrentMonth: boolean): { backgroundCo
 function getBadgeStyle(ratio: number, isCurrentMonth: boolean): Record<string, string> {
   if (props.showStatsOnly) {
     if (!isCurrentMonth) return {};
-    return { "--badge-pomo-color": getPomoColor(ratio) };
+    return {
+      "--badge-pomo-color": getPomoColor(ratio),
+      "--badge-bg-color": getStatsBadgeBgColor(ratio),
+    };
   }
   return { color: getPomoColor(ratio), backgroundColor: getPomoBgColorHEX(ratio) };
+}
+
+/** 统计模式 badge 底：低番茄灰底，高番茄过渡到白 */
+function getStatsBadgeBgColor(ratio: number): string {
+  const clamp = (v: number, min = 0, max = 1) => Math.min(max, Math.max(min, v));
+  const r = clamp(ratio);
+  const from = { r: 0xef, g: 0xef, b: 0xef };
+  const to = { r: 0xff, g: 0xff, b: 0xff };
+  const lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
+  const hex = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${hex(lerp(from.r, to.r, r))}${hex(lerp(from.g, to.g, r))}${hex(lerp(from.b, to.b, r))}`;
 }
 
 /** 统计模式整格底色：0 番茄为透明白，随 ratio 渐变为玫红 */
@@ -412,12 +445,12 @@ function getStatsPomoBgColorHEX(ratio: number) {
   const clamp = (v: number, min = 0, max = 1) => Math.min(max, Math.max(min, v));
   const r = clamp(ratio);
   const from = { r: 0xff, g: 0xff, b: 0xff, a: 0 };
-  const to = { r: 0xd6, g: 0x48, b: 0x64, a: 0.3 };
+  const to = { r: 0xd6, g: 0x48, b: 0x64, a: STATS_POMO_BG_MAX_ALPHA };
   const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
   const R = Math.round(lerp(from.r, to.r, r));
   const G = Math.round(lerp(from.g, to.g, r));
   const B = Math.round(lerp(from.b, to.b, r));
-  const A = Math.round(lerp(from.a, to.a, r) * 255);
+  const A = Math.round(lerp(from.a, to.a, mapStatsPomoAlphaRatio(r)) * 255);
   const hex = (n: number) => n.toString(16).padStart(2, "0");
   return `#${hex(R)}${hex(G)}${hex(B)}${hex(A)}`;
 }
@@ -549,10 +582,15 @@ function getPomoBgColorHEX(ratio: number) {
   z-index: 100;
 }
 
-/* 统计模式：番茄底色移到整格（仅本月），badge 灰底 + 渐变字色 */
+/* 统计模式：番茄底色移到整格（仅本月），badge 灰→白底 + 渐变字色 */
 .day-card--stats .date-badge.date-badge--stats {
-  background-color: var(--color-background-light) !important;
+  background-color: var(--badge-bg-color, var(--color-background-light)) !important;
   color: var(--badge-pomo-color, var(--color-text-secondary)) !important;
+}
+
+.day-card--stats .date-badge.date-badge--stats.today {
+  color: white !important;
+  background-color: var(--color-blue) !important;
 }
 
 .day-card--other-month .date-badge {
@@ -645,6 +683,12 @@ function getPomoBgColorHEX(ratio: number) {
     color: var(--color-blue) !important;
   }
 
+  .day-card--stats .date-badge.date-badge--stats:hover {
+    cursor: pointer;
+    background-color: var(--color-blue-light) !important;
+    color: var(--color-blue) !important;
+  }
+
   .item:hover:not(.item--selected) {
     background-color: var(--color-hover, rgba(0, 0, 0, 0.05));
   }
@@ -719,7 +763,7 @@ function getPomoBgColorHEX(ratio: number) {
   line-height: 1.2;
   color: var(--color-text-primary);
   font-weight: 600;
-  padding: 2px 4px 4px;
+  padding-bottom: 12px;
 }
 
 .day-stat--compact {
@@ -818,8 +862,13 @@ function getPomoBgColorHEX(ratio: number) {
     z-index: 10;
   }
 
+  .day-card--stats .date-badge.date-badge--stats.today {
+    color: var(--color-background) !important;
+    background-color: var(--color-blue) !important;
+  }
+
   /* 触摸端无 hover：整格选中时日期徽章与桌面 .date-badge:hover 一致 */
-  .day-card--selected .date-badge:not(.date-badge--stats) {
+  .day-card--selected .date-badge {
     background-color: var(--color-blue-light) !important;
     color: var(--color-blue) !important;
   }

--- a/src/core/ledger/parseLedgerSegments.ts
+++ b/src/core/ledger/parseLedgerSegments.ts
@@ -136,7 +136,38 @@ function findLedgerRegion(strippedTitle: string): LedgerRegion | null {
 }
 
 function extractSegmentStrings(body: string): string[] {
-  const normalized = body.replace(/；/g, ";").replace(/;/g, " ");
+  const parts: string[] = [];
+  for (const chunk of body.split(/[;；]/)) {
+    const trimmed = chunk.trim();
+    if (!trimmed) continue;
+
+    if (!/^[+-]/.test(trimmed)) {
+      const leadingMatch = trimmed.match(/^(.+?)\s+([-+].*)$/);
+      if (leadingMatch) {
+        const memo = leadingMatch[1]!.trim();
+        const restParts = extractSegmentStringsFromChunk(leadingMatch[2]!.trim());
+        if (restParts.length > 0) {
+          parts.push(attachLeadingMemo(restParts[0]!, memo));
+          parts.push(...restParts.slice(1));
+          continue;
+        }
+      }
+    }
+
+    parts.push(...extractSegmentStringsFromChunk(trimmed));
+  }
+  return parts;
+}
+
+/** 分号分段后段首文字（如「午饭 -30」）并入首段 memo */
+function attachLeadingMemo(piece: string, memo: string): string {
+  const m = piece.match(/^([+-])(\d+(?:\.\d{1,2})?)(.*)$/);
+  if (!m) return piece;
+  const tail = m[3]?.trim();
+  return tail ? `${m[1]}${m[2]} ${memo} ${tail}` : `${m[1]}${m[2]} ${memo}`;
+}
+
+function extractSegmentStringsFromChunk(normalized: string): string[] {
   const parts: string[] = [];
   let i = 0;
 


### PR DESCRIPTION
- 番茄月视图颜色不明显调整
- 录入收支对分号兼容
- 提示第一个bug不存在，当前数据解包方式正确

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 记账标题解析语义有变（分号分段与 memo 归属），可能影响用户已有录入习惯；其余为展示层调整，风险较低。
> 
> **Overview**
> **记账录入**在 `parseLedgerSegments` 中改为按 `;` / `；` 真正分段，不再把分号当成空格；分号后若段首是文字再跟金额（如 `午饭 -30`），会把该文字并入**下一段**的 memo，收入段不再误带上一段的备注。对应单测已更新。
> 
> **月视图统计模式**（`MonthPlanner`）用新的番茄数→颜色 ratio 映射，让 1–2 个番茄的玫红底更明显；整格底色 alpha 上限提高到 0.45，日期徽章底从灰渐变到白；**今天**在统计模式下仍保持蓝色高亮，并补齐 stats 模式下的 hover / 选中样式。
> 
> **收支统计 UI**：`LedgerAggregatePopover` 去掉明细表「暂无记账」空行；`LedgerMiniChart` 空饼图文案改用次要文字色，趋势图去掉无数据时的居中占位并略收紧左侧边距。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d8af47b940c7afca893ac406fdd3bff695ba84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->