### PR TITLE
debug 记账 登陆删除本地数据失败

### DIFF
--- a/src/__tests__/ledgerQueryService.test.ts
+++ b/src/__tests__/ledgerQueryService.test.ts
@@ -146,6 +146,44 @@ describe("buildLedgerTrend", () => {
     expect(buckets[3]?.label).not.toContain("今");
     expect(buckets[3]?.start).toBe(getDayStartTimestamp(center));
   });
+
+  it("年视图无数据时固定 12 个月桶", () => {
+    const yearStart = getDayStartTimestamp(new Date(2026, 0, 1).getTime());
+    const yearEnd = getDayStartTimestamp(new Date(2027, 0, 1).getTime());
+    const buckets = buildLedgerTrend([], yearStart, yearEnd, "year", () => undefined);
+    expect(buckets).toHaveLength(12);
+    expect(buckets.map((b) => b.label)).toEqual([
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ]);
+    expect(buckets.every((b) => b.expense === 0 && b.income === 0)).toBe(true);
+  });
+
+  it("年视图按 todo.id 归入对应月份", () => {
+    const julyTodoTs = getDayStartTimestamp(new Date(2026, 6, 15).getTime()) + 3600_000;
+    const yearStart = getDayStartTimestamp(new Date(2026, 0, 1).getTime());
+    const yearEnd = getDayStartTimestamp(new Date(2027, 0, 1).getTime());
+    const buckets = buildLedgerTrend(
+      [entry({ id: 999_999, sourceTodoId: julyTodoTs, sourceActivityId: 1, amount: 42 })],
+      yearStart,
+      yearEnd,
+      "year",
+      todoMap({ id: julyTodoTs }),
+    );
+    expect(buckets).toHaveLength(12);
+    expect(buckets.filter((b) => b.expense > 0)).toHaveLength(1);
+    expect(buckets.find((b) => b.label === "Jul")?.expense).toBe(42);
+  });
 });
 
 describe("buildLedgerTableRows", () => {
@@ -184,6 +222,28 @@ describe("aggregateLedger", () => {
     });
     expect(result.stats.entryCount).toBe(2);
     expect(result.stats.net).toBe(70);
+  });
+
+  it("年视图汇总全年条目并分月趋势", () => {
+    const julyTodoTs = getDayStartTimestamp(new Date(2026, 6, 10).getTime()) + 5000;
+    const yearStart = getDayStartTimestamp(new Date(2026, 0, 1).getTime());
+    const yearEnd = getDayStartTimestamp(new Date(2027, 0, 1).getTime());
+    const result = aggregateLedger({
+      entries: [entry({ id: 10, sourceTodoId: julyTodoTs, sourceActivityId: 1, amount: 30, direction: "expense" })],
+      rangeStart: yearStart,
+      rangeEnd: yearEnd,
+      viewScale: "year",
+      filterTagIds: [],
+      filterStarredOnly: false,
+      getTodoById: todoMap({ id: julyTodoTs }),
+      getActivityTagIds: () => [],
+      hasStarredTaskForActivity: () => false,
+      getTagName: tagName,
+    });
+    expect(result.stats.entryCount).toBe(1);
+    expect(result.stats.totalExpense).toBe(30);
+    expect(result.trend).toHaveLength(12);
+    expect(result.trend.find((b) => b.label === "Jul")?.expense).toBe(30);
   });
 });
 

--- a/src/__tests__/ledgerQueryService.test.ts
+++ b/src/__tests__/ledgerQueryService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { LedgerEntry } from "@/core/types/LedgerEntry";
-import type { LedgerTodoRef } from "@/services/ledger/ledgerQueryService";
+import type { LedgerTodoRef, LedgerScheduleRef } from "@/services/ledger/ledgerQueryService";
 import {
   aggregateLedger,
   buildLedgerPie,
@@ -23,6 +23,7 @@ function entry(
     lastModified: partial.id,
     synced: false,
     deleted: false,
+    sourceScheduleId: 0,
     ...partial,
   };
 }
@@ -30,9 +31,21 @@ function entry(
 const dayStart = getDayStartTimestamp(new Date(2026, 5, 15).getTime());
 const tagName = (id: number) => ({ 1: "生存", 2: "看病", 3: "学习" })[id];
 
-function todoMap(...items: LedgerTodoRef[]): (id: number) => LedgerTodoRef | undefined {
+function todoLookup(...items: LedgerTodoRef[]) {
   const map = new Map(items.map((t) => [t.id, t]));
-  return (id) => map.get(id);
+  return { getTodoById: (id: number) => map.get(id) };
+}
+
+function scheduleLookup(
+  byId: LedgerScheduleRef[],
+  byActivity?: Map<number, LedgerScheduleRef>,
+) {
+  const idMap = new Map(byId.map((s) => [s.id, s]));
+  return {
+    getTodoById: () => undefined,
+    getScheduleById: (id: number) => idMap.get(id),
+    getScheduleByActivityId: (activityId: number) => byActivity?.get(activityId),
+  };
 }
 
 describe("filterLedgerEntries", () => {
@@ -49,7 +62,7 @@ describe("filterLedgerEntries", () => {
       viewScale: "day",
       filterTagIds: [99],
       filterStarredOnly: false,
-      getTodoById: todoMap({ id: todoTs }, { id: dayStart + 7200_000 }),
+      getTodoById: todoLookup({ id: todoTs }, { id: dayStart + 7200_000 }).getTodoById,
       getActivityTagIds: (id) => (id === 10 ? [99] : [88]),
       hasStarredTaskForActivity: () => false,
       getTagName: tagName,
@@ -70,7 +83,7 @@ describe("filterLedgerEntries", () => {
       viewScale: "day",
       filterTagIds: [],
       filterStarredOnly: false,
-      getTodoById: todoMap({ id: todoTs }),
+      getTodoById: todoLookup({ id: todoTs }).getTodoById,
       getActivityTagIds: () => [],
       hasStarredTaskForActivity: () => false,
       getTagName: tagName,
@@ -82,7 +95,7 @@ describe("filterLedgerEntries", () => {
       viewScale: "day",
       filterTagIds: [],
       filterStarredOnly: false,
-      getTodoById: todoMap({ id: todoTs }),
+      getTodoById: todoLookup({ id: todoTs }).getTodoById,
       getActivityTagIds: () => [],
       hasStarredTaskForActivity: () => false,
       getTagName: tagName,
@@ -133,7 +146,7 @@ describe("buildLedgerTrend", () => {
       weekStart,
       weekStart + 7 * 86_400_000,
       "week",
-      todoMap({ id: todoTs }),
+      todoLookup({ id: todoTs }),
     );
     expect(buckets).toHaveLength(7);
     expect(buckets[0].expense).toBe(5);
@@ -141,7 +154,7 @@ describe("buildLedgerTrend", () => {
 
   it("日视图前后各 3 天共 7 桶", () => {
     const center = dayStart + 12 * 3_600_000;
-    const buckets = buildLedgerTrend([], center, center + 86_400_000, "day", () => undefined);
+    const buckets = buildLedgerTrend([], center, center + 86_400_000, "day", { getTodoById: () => undefined });
     expect(buckets).toHaveLength(7);
     expect(buckets[3]?.label).not.toContain("今");
     expect(buckets[3]?.start).toBe(getDayStartTimestamp(center));
@@ -150,7 +163,7 @@ describe("buildLedgerTrend", () => {
   it("年视图无数据时固定 12 个月桶", () => {
     const yearStart = getDayStartTimestamp(new Date(2026, 0, 1).getTime());
     const yearEnd = getDayStartTimestamp(new Date(2027, 0, 1).getTime());
-    const buckets = buildLedgerTrend([], yearStart, yearEnd, "year", () => undefined);
+    const buckets = buildLedgerTrend([], yearStart, yearEnd, "year", { getTodoById: () => undefined });
     expect(buckets).toHaveLength(12);
     expect(buckets.map((b) => b.label)).toEqual([
       "Jan",
@@ -178,7 +191,7 @@ describe("buildLedgerTrend", () => {
       yearStart,
       yearEnd,
       "year",
-      todoMap({ id: julyTodoTs }),
+      todoLookup({ id: julyTodoTs }),
     );
     expect(buckets).toHaveLength(12);
     expect(buckets.filter((b) => b.expense > 0)).toHaveLength(1);
@@ -195,7 +208,7 @@ describe("buildLedgerTableRows", () => {
         entry({ id: 3, sourceTodoId: 102, sourceActivityId: 1, amount: 20, direction: "expense" }),
       ],
       tagName,
-      todoMap({ id: 100 }, { id: 101 }, { id: 102 }),
+      todoLookup({ id: 100 }, { id: 101 }, { id: 102 }),
       "time",
     );
     expect(rows.map((r) => r.direction)).toEqual(["income", "expense", "expense"]);
@@ -215,7 +228,7 @@ describe("aggregateLedger", () => {
       viewScale: "day",
       filterTagIds: [],
       filterStarredOnly: false,
-      getTodoById: todoMap({ id: dayStart }, { id: dayStart + 1000 }),
+      getTodoById: todoLookup({ id: dayStart }, { id: dayStart + 1000 }).getTodoById,
       getActivityTagIds: () => [],
       hasStarredTaskForActivity: () => false,
       getTagName: tagName,
@@ -235,7 +248,7 @@ describe("aggregateLedger", () => {
       viewScale: "year",
       filterTagIds: [],
       filterStarredOnly: false,
-      getTodoById: todoMap({ id: julyTodoTs }),
+      getTodoById: todoLookup({ id: julyTodoTs }).getTodoById,
       getActivityTagIds: () => [],
       hasStarredTaskForActivity: () => false,
       getTagName: tagName,
@@ -250,11 +263,50 @@ describe("aggregateLedger", () => {
 describe("resolveLedgerPlannerTs", () => {
   it("云下载无 sourceTodoId 时经 activity_id 反查 todo", () => {
     const todoTs = dayStart + 3600_000;
-    const ts = resolveLedgerPlannerTs(
-      entry({ id: 1, sourceTodoId: 0, sourceActivityId: 42 }),
-      () => undefined,
-      () => ({ id: todoTs }),
-    );
+    const ts = resolveLedgerPlannerTs(entry({ id: 1, sourceTodoId: 0, sourceActivityId: 42 }), {
+      getTodoById: () => undefined,
+      getTodoByActivityId: () => ({ id: todoTs }),
+    });
     expect(ts).toBe(todoTs);
+  });
+
+  it("schedule 行按 activityDueRange[0] 归日", () => {
+    const dueTs = dayStart + 5 * 3_600_000;
+    const scheduleId = 88_001;
+    const ts = resolveLedgerPlannerTs(
+      entry({ id: 1, sourceTodoId: 0, sourceScheduleId: scheduleId, sourceActivityId: 50 }),
+      scheduleLookup([{ id: scheduleId, activityDueRange: [dueTs, "60"] }]),
+    );
+    expect(ts).toBe(dueTs);
+  });
+
+  it("云下载无 sourceScheduleId 时经 activity_id 反查 schedule", () => {
+    const dueTs = dayStart + 2 * 3_600_000;
+    const ts = resolveLedgerPlannerTs(entry({ id: 1, sourceTodoId: 0, sourceActivityId: 77 }), {
+      getTodoById: () => undefined,
+      getScheduleByActivityId: () => ({ id: 1, activityDueRange: [dueTs, "30"] }),
+    });
+    expect(ts).toBe(dueTs);
+  });
+});
+
+describe("filterLedgerEntries schedule", () => {
+  it("按 schedule activityDueRange 筛选", () => {
+    const dueTs = dayStart + 4 * 3_600_000;
+    const scheduleId = 55_001;
+    const filtered = filterLedgerEntries({
+      entries: [entry({ id: 1, sourceTodoId: 0, sourceScheduleId: scheduleId, sourceActivityId: 9 })],
+      rangeStart: dayStart,
+      rangeEnd: dayStart + 86_400_000,
+      viewScale: "day",
+      filterTagIds: [],
+      filterStarredOnly: false,
+      getTodoById: () => undefined,
+      getScheduleById: (id) => (id === scheduleId ? { id: scheduleId, activityDueRange: [dueTs, "0"] } : undefined),
+      getActivityTagIds: () => [],
+      hasStarredTaskForActivity: () => false,
+      getTagName: tagName,
+    });
+    expect(filtered).toHaveLength(1);
   });
 });

--- a/src/__tests__/ledgerService.test.ts
+++ b/src/__tests__/ledgerService.test.ts
@@ -22,6 +22,27 @@ describe("syncLedgerFromTodoTitle v1", () => {
     },
   };
 
+  it("schedule title 写入 sourceScheduleId", () => {
+    const result = syncLedgerFromTodoTitle(
+      ledgerList,
+      {
+        activityId: 200,
+        scheduleId: 55_002,
+        rawTitle: "-15 咖啡￥",
+        defaultCurrency: "CNY",
+      },
+      tagActions,
+    );
+    expect(result.appendedCount).toBe(1);
+    expect(ledgerList[0]).toMatchObject({
+      sourceActivityId: 200,
+      sourceTodoId: 0,
+      sourceScheduleId: 55_002,
+      amount: 15,
+    });
+    expect(result.normalizedTitle).toBe("咖啡（-15）");
+  });
+
   it("解析记账段、回写日记与汇总括号", () => {
     const result = syncLedgerFromTodoTitle(
       ledgerList,

--- a/src/__tests__/ledgerSync.test.ts
+++ b/src/__tests__/ledgerSync.test.ts
@@ -90,6 +90,7 @@ describe("LedgerSyncService", () => {
       expect(local.categoryTagIds).toEqual([1]);
       expect(local.sourceActivityId).toBe(100);
       expect(local.sourceTodoId).toBe(0);
+      expect(local.sourceScheduleId).toBe(0);
       expect(local.synced).toBe(true);
       expect(local.deleted).toBe(false);
       expect(local.cloudModified).toBe(new Date("2026-07-01T00:00:00.000Z").getTime());

--- a/src/components/DayPlanner/DaySchedule.vue
+++ b/src/components/DayPlanner/DaySchedule.vue
@@ -223,6 +223,7 @@
               @click.stop="startEditing(schedule.id, 'title')"
               :title="editingRowId === schedule.id && editingField === 'title' ? '' : '单击编辑'"
             >
+              <div class="title-cell-inner">
               <input
                 class="title-input"
                 v-if="editingRowId === schedule.id && editingField === 'title'"
@@ -259,7 +260,12 @@
                   <span style="display: inline-block; width: 1px; height: 1px; pointer-events: none"></span>
                 </template>
               </TagPickerPopover>
-              <span class="ellipsis" v-else>{{ schedule.activityTitle ?? "-" }}</span>
+              <span class="ellipsis" v-if="!(editingRowId === schedule.id && editingField === 'title')">{{ schedule.activityTitle ?? "-" }}</span>
+              <LedgerEntryPopover
+                v-if="ledgerEntriesForSchedule(schedule).length > 0"
+                :entries="ledgerEntriesForSchedule(schedule)"
+                @delete="(id) => handleLedgerDelete(schedule, id)"
+              />
 
               <!-- 云朵背景元素 - 只有当 isUntaetigkeit 为 true 时才显示 -->
               <template v-if="schedule.isUntaetigkeit === true">
@@ -270,6 +276,7 @@
                 <div class="cloud cloud-5"></div>
                 <div class="cloud cloud-6"></div>
               </template>
+              </div>
             </td>
 
             <!-- 6 地点 -->
@@ -354,6 +361,11 @@ import { storeToRefs } from "pinia";
 import { useActivityTagEditor } from "@/composables/activity/useActivityTagEditor";
 import TagPickerPopover from "../TagSystem/TagPickerPopover.vue";
 import { useDevice } from "@/composables/platform/useDevice";
+import LedgerEntryPopover from "@/components/Ledger/LedgerEntryPopover.vue";
+import type { LedgerEntry } from "@/core/types/LedgerEntry";
+import { getTitleTagPickerMode, replaceTagTriggerWithCategory } from "@/core/ledger/parseLedgerSegments";
+import { softDeleteLedgerEntryWithTitle } from "@/services/ledger/ledgerService";
+import { useTagStore } from "@/stores/useTagStore";
 
 const props = withDefaults(
   defineProps<{
@@ -365,8 +377,33 @@ const props = withDefaults(
 );
 
 const dataStore = useDataStore();
+const tagStore = useTagStore();
 const { isMobile } = useDevice();
-const { activeId, selectedRowId, selectedActivityId, selectedTaskId, selectedTask, schedulesForCurrentView } = storeToRefs(dataStore);
+const { activeId, selectedRowId, selectedActivityId, selectedTaskId, selectedTask, schedulesForCurrentView, ledgerList } = storeToRefs(dataStore);
+
+const ledgerEntriesByActivityId = computed(() => {
+  const map = new Map<number, LedgerEntry[]>();
+  for (const entry of ledgerList.value) {
+    if (entry.deleted) continue;
+    const list = map.get(entry.sourceActivityId) ?? [];
+    list.push(entry);
+    map.set(entry.sourceActivityId, list);
+  }
+  for (const list of map.values()) {
+    list.sort((a, b) => a.segmentIndex - b.segmentIndex);
+  }
+  return map;
+});
+
+function ledgerEntriesForSchedule(schedule: Schedule): LedgerEntry[] {
+  return ledgerEntriesByActivityId.value.get(schedule.activityId) ?? [];
+}
+
+function handleLedgerDelete(schedule: Schedule, entryId: number) {
+  const currentTitle = schedule.activityTitle ?? "";
+  const { title } = softDeleteLedgerEntryWithTitle(ledgerList.value, entryId, currentTitle);
+  emit("edit-schedule-title", schedule.id, title);
+}
 
 // 当前视图是否为今天（仅今天时已完成行才变灰）
 const dateService = dataStore.dateService;
@@ -774,12 +811,18 @@ function handleTagSelected(tagId: number) {
   const schedule = schedulesForCurrentView.value.find((s) => s.id === tagEditor.popoverTargetId.value);
   if (!schedule) return;
 
-  const cleanedTitle = tagEditor.clearTagTriggerText(editingValue.value);
-  editingValue.value = cleanedTitle;
-
-  // 通过 activityId 给 Activity 添加标签
-  dataStore.addTagToActivity(schedule.activityId, tagId);
-  tagEditor.closePopover();
+  if (getTitleTagPickerMode(editingValue.value) === "ledgerText") {
+    const name = tagStore.getTag(tagId)?.name ?? String(tagId);
+    editingValue.value = replaceTagTriggerWithCategory(editingValue.value, name);
+    tagEditor.closePopover();
+  } else {
+    const cleanedTitle = tagEditor.clearTagTriggerText(editingValue.value);
+    editingValue.value = cleanedTitle;
+    dataStore.addTagToActivity(schedule.activityId, tagId);
+    tagEditor.closePopover();
+  }
+  isPickingTagFromSelector.value = false;
+  nextTick(() => titleInputRef.value?.focus());
 }
 
 function handleTagCreate(tagName: string) {
@@ -787,12 +830,17 @@ function handleTagCreate(tagName: string) {
   const schedule = schedulesForCurrentView.value.find((s) => s.id === tagEditor.popoverTargetId.value);
   if (!schedule) return;
 
-  const cleanedTitle = tagEditor.clearTagTriggerText(editingValue.value);
-  editingValue.value = cleanedTitle;
-
-  // 通过 activityId 创建并添加标签到 Activity
-  dataStore.createAndAddTagToActivity(schedule.activityId, tagName);
-  tagEditor.closePopover();
+  if (getTitleTagPickerMode(editingValue.value) === "ledgerText") {
+    editingValue.value = replaceTagTriggerWithCategory(editingValue.value, tagName);
+    tagEditor.closePopover();
+  } else {
+    const cleanedTitle = tagEditor.clearTagTriggerText(editingValue.value);
+    editingValue.value = cleanedTitle;
+    dataStore.createAndAddTagToActivity(schedule.activityId, tagName);
+    tagEditor.closePopover();
+  }
+  isPickingTagFromSelector.value = false;
+  nextTick(() => titleInputRef.value?.focus());
 }
 
 function averageValue<T extends { value: number }>(records: T[] | null | undefined): number | string {
@@ -1076,6 +1124,22 @@ td.status-col {
 }
 
 /* 补充：让省略容器具备可计算宽度并允许收缩 */
+.title-cell-inner {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+}
+
+td.col-intent .title-cell-inner .ellipsis {
+  flex: 1 1 auto;
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .col-location .ellipsis,
 .col-intent .ellipsis {
   display: block; /* 或 inline-block */

--- a/src/components/Ledger/LedgerEntryPanel.vue
+++ b/src/components/Ledger/LedgerEntryPanel.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="ledger-entry-panel">
+    <div v-if="!hideTitle" class="ledger-entry-panel__title">收支 {{ entries.length }} 笔</div>
+    <table class="ledger-entry-table">
+      <colgroup>
+        <col class="ledger-entry-table__col-action" />
+        <col class="ledger-entry-table__col-tags" />
+        <col class="ledger-entry-table__col-memo" />
+        <col class="ledger-entry-table__col-amount" />
+      </colgroup>
+      <thead>
+        <tr>
+          <th class="ledger-entry-table__col-action" aria-hidden="true"></th>
+          <th>分类</th>
+          <th>备注</th>
+          <th class="ledger-entry-table__col-amount">金额</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="entry in entries" :key="entry.id">
+          <td class="ledger-entry-table__col-action">
+            <button type="button" class="ledger-entry-table__delete" title="删除" @click.stop="emit('delete', entry.id)">
+              <n-icon :size="14">
+                <Delete24Regular />
+              </n-icon>
+            </button>
+          </td>
+          <td class="ledger-entry-table__tags">{{ categoryNames(entry.categoryTagIds) }}</td>
+          <td class="ledger-entry-table__memo">{{ entry.memo || "—" }}</td>
+          <td class="ledger-entry-table__col-amount" :class="entry.direction === 'income' ? 'ledger-income' : 'ledger-expense'">
+            {{ formatAmount(entry) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { NIcon } from "naive-ui";
+import { Delete24Regular } from "@vicons/fluent";
+import type { LedgerEntry } from "@/core/types/LedgerEntry";
+import { formatLedgerMoneyFixed } from "@/services/ledger/ledgerQueryService";
+import { useTagStore } from "@/stores/useTagStore";
+
+defineProps<{
+  entries: LedgerEntry[];
+  /** modal 已有标题时隐藏面板内标题 */
+  hideTitle?: boolean;
+}>();
+
+const emit = defineEmits<{
+  delete: [entryId: number];
+}>();
+
+const tagStore = useTagStore();
+
+function formatAmount(entry: LedgerEntry): string {
+  const sign = entry.direction === "income" ? "+" : "-";
+  const cur = entry.currency && entry.currency !== "CNY" ? ` ${entry.currency}` : "";
+  return `${sign}${formatLedgerMoneyFixed(entry.amount)}${cur}`;
+}
+
+function categoryNames(tagIds?: number[]): string {
+  if (!tagIds || tagIds.length === 0) return "—";
+  return tagIds.map((id) => tagStore.getTag(id)?.name ?? `#${id}`).join(", ");
+}
+</script>
+
+<style scoped>
+.ledger-entry-panel__title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--color-text-secondary);
+}
+
+.ledger-entry-table {
+  border-collapse: collapse;
+  font-size: 12px;
+  width: max-content;
+  max-width: 100%;
+  table-layout: fixed;
+}
+
+.ledger-entry-table__col-tags {
+  width: 124px;
+}
+
+.ledger-entry-table__col-memo {
+  width: 72px;
+}
+
+.ledger-entry-table th,
+.ledger-entry-table td {
+  padding: 4px 6px;
+  text-align: left;
+  border-bottom: 1px solid var(--n-border-color);
+  vertical-align: middle;
+}
+
+.ledger-entry-table th {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.ledger-entry-table__memo,
+.ledger-entry-table__tags {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ledger-entry-table th.ledger-entry-table__col-amount,
+.ledger-entry-table td.ledger-entry-table__col-amount {
+  width: 72px;
+  padding-left: 4px;
+  padding-right: 2px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.ledger-entry-table__col-action {
+  width: 18px;
+  min-width: 18px;
+  max-width: 18px;
+  padding: 0 2px 0 0;
+  text-align: center;
+  overflow: visible;
+}
+
+.ledger-entry-table col.ledger-entry-table__col-action {
+  width: 18px;
+}
+
+.ledger-entry-table__delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-red-dark, #d03050);
+  cursor: pointer;
+  line-height: 0;
+  vertical-align: middle;
+}
+
+.ledger-entry-table__delete:hover {
+  opacity: 0.85;
+}
+
+.ledger-income {
+  color: var(--color-green-dark, #18a058);
+}
+
+.ledger-expense {
+  color: var(--color-red-dark, #d03050);
+}
+</style>

--- a/src/components/Ledger/LedgerEntryPopover.vue
+++ b/src/components/Ledger/LedgerEntryPopover.vue
@@ -1,56 +1,53 @@
 <template>
-  <n-popover trigger="click" placement="bottom-end" class="ledger-entry-popover" :z-index="10001" @click.stop>
+  <template v-if="useCenteredPanel">
+    <n-icon :size="12" class="ledger-entry-suffix ledger-entry-suffix--mobile" :title="triggerTitle" @click.stop="openPanel">
+      <Wallet20Regular />
+    </n-icon>
+    <n-modal
+      v-model:show="showPanel"
+      preset="card"
+      class="ledger-entry-modal"
+      :title="`收支 ${entries.length} 笔`"
+      :style="{ width: 'fit-content', maxWidth: 'min(340px, 92vw)' }"
+      :mask-closable="true"
+      @click.stop
+    >
+      <LedgerEntryPanel :entries="entries" hide-title @delete="onDelete" />
+    </n-modal>
+  </template>
+
+  <n-popover
+    v-else
+    trigger="click"
+    placement="bottom-end"
+    to="body"
+    :scrollable="true"
+    :flip="true"
+    :shift="true"
+    class="ledger-entry-popover"
+    :z-index="10001"
+    @click.stop
+  >
     <template #trigger>
-      <n-button v-if="!isMobile" text class="ledger-entry-suffix" :title="triggerTitle" @click.stop>
+      <n-button text class="ledger-entry-suffix" :title="triggerTitle" @click.stop>
         <template #icon>
           <n-icon :size="16">
             <Wallet20Regular />
           </n-icon>
         </template>
       </n-button>
-      <n-icon v-else :size="12" class="ledger-entry-suffix ledger-entry-suffix--mobile" :title="triggerTitle" @click.stop>
-        <Wallet20Regular />
-      </n-icon>
     </template>
-    <div class="ledger-entry-panel">
-      <div class="ledger-entry-panel__title">收支 {{ entries.length }} 笔</div>
-      <table class="ledger-entry-table">
-        <thead>
-          <tr>
-            <th>方向</th>
-            <th>金额</th>
-            <th>备注</th>
-            <th>分类</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="entry in entries" :key="entry.id">
-            <td :class="entry.direction === 'income' ? 'ledger-income' : 'ledger-expense'">
-              {{ entry.direction === "income" ? "收入" : "支出" }}
-            </td>
-            <td>{{ formatAmount(entry) }}</td>
-            <td>{{ entry.memo || "—" }}</td>
-            <td>{{ categoryNames(entry.categoryTagIds) }}</td>
-            <td>
-              <n-button text type="error" size="tiny" title="删除" @click.stop="emit('delete', entry.id)">删</n-button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <div v-if="summaryLine" class="ledger-entry-panel__summary">{{ summaryLine }}</div>
-    </div>
+    <LedgerEntryPanel :entries="entries" @delete="onDelete" />
   </n-popover>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
-import { NButton, NIcon, NPopover } from "naive-ui";
+import { computed, ref } from "vue";
+import { NButton, NIcon, NModal, NPopover } from "naive-ui";
 import { Wallet20Regular } from "@vicons/fluent";
 import { useDevice } from "@/composables/platform/useDevice";
 import type { LedgerEntry } from "@/core/types/LedgerEntry";
-import { formatLedgerSummaryBracket } from "@/core/ledger/parseLedgerSegments";
-import { useTagStore } from "@/stores/useTagStore";
+import LedgerEntryPanel from "@/components/Ledger/LedgerEntryPanel.vue";
 
 const props = defineProps<{
   entries: LedgerEntry[];
@@ -60,25 +57,20 @@ const emit = defineEmits<{
   delete: [entryId: number];
 }>();
 
-const tagStore = useTagStore();
-const { isMobile } = useDevice();
+const { isMobile, width } = useDevice();
+const showPanel = ref(false);
+
+/** 手机真机 + 窄屏预览：居中 modal，避免表格滚动区内 popover 偏移 */
+const useCenteredPanel = computed(() => isMobile.value || width.value < 768);
 
 const triggerTitle = computed(() => `已录入 ${props.entries.length} 笔收支，点击查看`);
 
-const summaryLine = computed(() => {
-  const bracket = formatLedgerSummaryBracket(props.entries);
-  return bracket ? `合计 ${bracket}` : "";
-});
-
-function formatAmount(entry: LedgerEntry): string {
-  const sign = entry.direction === "income" ? "+" : "-";
-  const cur = entry.currency && entry.currency !== "CNY" ? ` ${entry.currency}` : "";
-  return `${sign}${entry.amount}${cur}`;
+function openPanel() {
+  showPanel.value = true;
 }
 
-function categoryNames(tagIds?: number[]): string {
-  if (!tagIds || tagIds.length === 0) return "—";
-  return tagIds.map((id) => tagStore.getTag(id)?.name ?? `#${id}`).join(", ");
+function onDelete(entryId: number) {
+  emit("delete", entryId);
 }
 </script>
 
@@ -102,44 +94,15 @@ function categoryNames(tagIds?: number[]): string {
   padding: 0;
   cursor: pointer;
 }
+</style>
 
-.ledger-entry-panel__title {
-  font-size: 12px;
-  font-weight: 600;
-  margin-bottom: 6px;
-  color: var(--color-text-secondary);
+<!-- modal teleport 到 body，关闭按钮样式需全局 -->
+<style>
+.ledger-entry-modal .n-base-close::before {
+  background-color: transparent !important;
 }
 
-.ledger-entry-panel__summary {
-  margin-top: 6px;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-}
-
-.ledger-entry-table {
-  border-collapse: collapse;
-  font-size: 12px;
-  min-width: 260px;
-}
-
-.ledger-entry-table th,
-.ledger-entry-table td {
-  padding: 4px 8px;
-  text-align: left;
-  border-bottom: 1px solid var(--n-border-color);
-  white-space: nowrap;
-}
-
-.ledger-entry-table th {
-  color: var(--color-text-secondary);
-  font-weight: 500;
-}
-
-.ledger-income {
-  color: var(--color-green-dark, #18a058);
-}
-
-.ledger-expense {
-  color: var(--color-red-dark, #d03050);
+.ledger-entry-modal .n-base-close:not(.n-base-close--disabled):hover::before {
+  background-color: transparent !important;
 }
 </style>

--- a/src/composables/home/useHomePlannerRowEdits.ts
+++ b/src/composables/home/useHomePlannerRowEdits.ts
@@ -50,6 +50,8 @@ interface UseHomePlannerRowEditsOptions {
   saveAllDebounced: () => void;
   /** Todo title 保存后同步 ledger，返回规范化 title */
   onTodoTitleSaved?: (todoId: number, rawTitle: string) => string;
+  /** Schedule title 保存后同步 ledger，返回规范化 title */
+  onScheduleTitleSaved?: (scheduleId: number, rawTitle: string) => string;
 }
 
 export function useHomePlannerRowEdits(options: UseHomePlannerRowEditsOptions) {
@@ -57,16 +59,17 @@ export function useHomePlannerRowEdits(options: UseHomePlannerRowEditsOptions) {
     const schedule = options.scheduleById.value.get(id);
     if (!schedule) return;
 
-    schedule.activityTitle = newTitle;
+    const normalizedTitle = options.onScheduleTitleSaved?.(id, newTitle) ?? newTitle;
+    schedule.activityTitle = normalizedTitle;
     const activity = options.activityById.value.get(schedule.activityId);
     if (!activity) return;
-    activity.title = newTitle;
+    activity.title = normalizedTitle;
     activity.synced = false;
     activity.lastModified = Date.now();
 
     const relatedTask = options.taskByActivityId.value.get(schedule.activityId);
     if (relatedTask) {
-      relatedTask.activityTitle = newTitle;
+      relatedTask.activityTitle = normalizedTitle;
     }
     options.saveAllDebounced();
   };

--- a/src/composables/ledger/useLedgerAggregatePanel.ts
+++ b/src/composables/ledger/useLedgerAggregatePanel.ts
@@ -3,7 +3,7 @@ import { storeToRefs } from "pinia";
 import { useDataStore } from "@/stores/useDataStore";
 import { useSettingStore } from "@/stores/useSettingStore";
 import { useTagStore } from "@/stores/useTagStore";
-import { getDayStartTimestamp } from "@/core/utils";
+import { addDays, getDayStartTimestamp } from "@/core/utils";
 import {
   aggregateLedger,
   formatLedgerMoney,
@@ -19,13 +19,24 @@ const EMPTY_AGGREGATE: LedgerAggregateResult = {
   tableRows: [],
 };
 
-function resolveVisibleRange(dataStore: ReturnType<typeof useDataStore>): { start: number; end: number } {
-  const raw = dataStore.dateService.visibleRange.value;
-  if (typeof raw?.start === "number" && typeof raw?.end === "number") {
-    return raw;
+/** 兼容 ComputedRef 与 Pinia 外链路偶尔已 unwrap 的情况 */
+function unwrapRefLike<T>(x: { value?: T } | T | undefined): T | undefined {
+  if (x === undefined || x === null) return undefined;
+  if (typeof x === "object" && x !== null && "value" in x && (x as { value: T }).value !== undefined) {
+    return (x as { value: T }).value;
   }
-  const start = getDayStartTimestamp();
-  return { start, end: start + 86_400_000 };
+  return x as T;
+}
+
+function resolveVisibleRange(dataStore: ReturnType<typeof useDataStore>): { start: number; end: number } {
+  const ds = dataStore.dateService;
+  const vr = unwrapRefLike<{ start: number; end: number }>(ds?.visibleRange);
+  if (vr && typeof vr.start === "number" && typeof vr.end === "number" && vr.end > vr.start) {
+    return vr;
+  }
+  const appTs = unwrapRefLike<number>(ds?.appDateTimestamp);
+  const dayStart = typeof appTs === "number" && !Number.isNaN(appTs) ? getDayStartTimestamp(appTs) : getDayStartTimestamp();
+  return { start: dayStart, end: addDays(dayStart, 1) };
 }
 
 const SCALE_LABEL: Record<LedgerViewScale, string> = {

--- a/src/composables/ledger/useLedgerAggregatePanel.ts
+++ b/src/composables/ledger/useLedgerAggregatePanel.ts
@@ -50,7 +50,7 @@ export function useLedgerAggregatePanel(tableSort: ComputedRef<LedgerTableSort>)
   const dataStore = useDataStore();
   const settingStore = useSettingStore();
   const tagStore = useTagStore();
-  const { ledgerList, filterTagIds, filterStarredOnly, todoById, todoByActivityId } = storeToRefs(dataStore);
+  const { ledgerList, filterTagIds, filterStarredOnly, todoById, todoByActivityId, scheduleById, scheduleByActivityId } = storeToRefs(dataStore);
 
   const viewScale = computed(() => settingStore.settings.viewSet as LedgerViewScale);
   const scaleLabel = computed(() => SCALE_LABEL[viewScale.value] ?? "日");
@@ -59,6 +59,7 @@ export function useLedgerAggregatePanel(tableSort: ComputedRef<LedgerTableSort>)
     const range = resolveVisibleRange(dataStore);
     const activityMap = toValue(dataStore.activityById);
     const todoMap = toValue(todoById);
+    const scheduleMap = toValue(scheduleById);
     return aggregateLedger(
       {
         entries: ledgerList.value ?? [],
@@ -69,6 +70,8 @@ export function useLedgerAggregatePanel(tableSort: ComputedRef<LedgerTableSort>)
         filterStarredOnly: filterStarredOnly.value,
         getTodoById: (todoId) => todoMap.get(todoId),
         getTodoByActivityId: (activityId) => todoByActivityId.value.get(activityId),
+        getScheduleById: (scheduleId) => scheduleMap.get(scheduleId),
+        getScheduleByActivityId: (activityId) => scheduleByActivityId.value.get(activityId),
         getActivityTagIds: (activityId) => activityMap.get(activityId)?.tagIds,
         hasStarredTaskForActivity: (id) => dataStore.hasStarredTaskForActivity(id),
         getTagName: (id) => tagStore.getTag(id)?.name,

--- a/src/core/auth/signedInSessionLifecycle.ts
+++ b/src/core/auth/signedInSessionLifecycle.ts
@@ -24,6 +24,8 @@ let authUnsubscribe: (() => void) | null = null;
 let lifecycleBootInProgress = false;
 /** 递增以使进行中的后台 initSyncLifecycle 在 await 间隙失效（登出/切账号与后台同步并发） */
 let backgroundSyncLifecycleToken = 0;
+/** 用户主动登出：SIGNED_OUT 回调跳过，待 signOut 完成后再 applySignedOut，避免清 storage 与 signOut 并发卡死 */
+let intentionalSignOutInProgress = false;
 
 export function cleanupSyncLifecycle(): void {
   const syncStore = useSyncStore();
@@ -204,6 +206,25 @@ function hasSupabaseAuthStorage(): boolean {
   return Object.keys(localStorage).some((key) => key.startsWith("sb-"));
 }
 
+/**
+ * 用户点击退出登录：先 signOut，再清本地；清除数据时 reload（与设置页「清空本地数据」一致）
+ */
+export async function performIntentionalSignOut(signOutFn: () => Promise<void>): Promise<void> {
+  const settingStore = useSettingStore();
+  const keep = settingStore.settings.keepLocalDataAfterSignOut || settingStore.settings.keepLocalDataOnNextSignOut;
+
+  intentionalSignOutInProgress = true;
+  try {
+    await signOutFn();
+    await applySignedOut();
+    if (!keep) {
+      window.location.reload();
+    }
+  } finally {
+    intentionalSignOutInProgress = false;
+  }
+}
+
 /** 登出清理（与 App 原逻辑一致） */
 export async function applySignedOut(): Promise<void> {
   const settingStore = useSettingStore();
@@ -251,6 +272,10 @@ export function subscribeAuthStateChanges(): void {
     if (event === "SIGNED_IN") {
       await applySignedInSession(session);
     } else if (event === "SIGNED_OUT") {
+      if (intentionalSignOutInProgress) {
+        appDebugLog("⏭️ 主动登出中，清理由 performIntentionalSignOut 串行执行");
+        return;
+      }
       const recovered = await recoverSessionFromStorage(event);
       if (recovered) {
         appDebugLog("♻️ SIGNED_OUT 后 session 仍可恢复，跳过登出清理");

--- a/src/core/types/LedgerEntry.ts
+++ b/src/core/types/LedgerEntry.ts
@@ -12,8 +12,10 @@ export interface LedgerEntry {
   rawSegment: string;
   segmentIndex: number;
   sourceActivityId: number;
-  /** 记账所在 todo；聚合日期用对应 todo.id（与 Planner 列表一致） */
+  /** 记账所在 todo；聚合日期用对应 todo.id（与 Planner 列表一致）；无则 0 */
   sourceTodoId: number;
+  /** 记账所在 schedule；聚合日期用 activityDueRange[0]；无则 0；云表不存，下载后靠 activity 反查 */
+  sourceScheduleId?: number;
   lastModified: number; // 最后修改时间戳
   cloudModified?: number; // 云端修改时间戳
   synced: boolean;

--- a/src/services/ledger/ledgerQueryService.ts
+++ b/src/services/ledger/ledgerQueryService.ts
@@ -264,6 +264,21 @@ function buildTrendBuckets(rangeStart: number, rangeEnd: number, viewScale: Ledg
     return buckets;
   }
 
+  if (viewScale === "year") {
+    const year = new Date(rangeStart).getFullYear();
+    for (let m = 0; m < 12; m++) {
+      const start = new Date(year, m, 1).getTime();
+      buckets.push({
+        key: `m-${start}`,
+        label: formatYearMonthLabel(start),
+        start,
+        expense: 0,
+        income: 0,
+      });
+    }
+    return buckets;
+  }
+
   let cursor = getStartOfMonth(rangeStart);
   while (cursor < rangeEnd) {
     buckets.push({

--- a/src/services/ledger/ledgerQueryService.ts
+++ b/src/services/ledger/ledgerQueryService.ts
@@ -8,6 +8,16 @@ export type LedgerTableSort = "time" | "tag";
 /** 与 todosForCurrentView 一致：todo.id 决定所属日 */
 export type LedgerTodoRef = { id: number; deleted?: boolean };
 
+/** 与 schedulesForCurrentView 一致：activityDueRange[0] 决定所属范围 */
+export type LedgerScheduleRef = { id: number; activityDueRange?: [number | null, string]; deleted?: boolean };
+
+export interface LedgerPlannerLookup {
+  getTodoById: (todoId: number) => LedgerTodoRef | undefined;
+  getTodoByActivityId?: (activityId: number) => LedgerTodoRef | undefined;
+  getScheduleById?: (scheduleId: number) => LedgerScheduleRef | undefined;
+  getScheduleByActivityId?: (activityId: number) => LedgerScheduleRef | undefined;
+}
+
 export interface LedgerQueryParams {
   entries: readonly LedgerEntry[];
   rangeStart: number;
@@ -17,6 +27,8 @@ export interface LedgerQueryParams {
   filterStarredOnly: boolean;
   getTodoById: (todoId: number) => LedgerTodoRef | undefined;
   getTodoByActivityId?: (activityId: number) => LedgerTodoRef | undefined;
+  getScheduleById?: (scheduleId: number) => LedgerScheduleRef | undefined;
+  getScheduleByActivityId?: (activityId: number) => LedgerScheduleRef | undefined;
   getActivityTagIds: (activityId: number) => number[] | undefined;
   hasStarredTaskForActivity: (activityId: number) => boolean;
   getTagName: (tagId: number) => string | undefined;
@@ -89,20 +101,47 @@ function incomeAmount(entry: LedgerEntry): number {
   return entry.direction === "income" ? entry.amount : 0;
 }
 
-/** activity 与 todo 1:1（todoByActivityId）；优先 sourceTodoId，否则按 sourceActivityId 查 todo */
-export function resolveLedgerPlannerTs(
-  entry: LedgerEntry,
-  getTodoById: (todoId: number) => LedgerTodoRef | undefined,
-  getTodoByActivityId?: (activityId: number) => LedgerTodoRef | undefined,
-): number | undefined {
-  const byTodoId = entry.sourceTodoId ? getTodoById(entry.sourceTodoId) : undefined;
-  const todo =
-    byTodoId && !byTodoId.deleted ? byTodoId : getTodoByActivityId?.(entry.sourceActivityId);
-  if (!todo || todo.deleted) return undefined;
-  return todo.id;
+function plannerLookup(params: LedgerQueryParams): LedgerPlannerLookup {
+  return {
+    getTodoById: params.getTodoById,
+    getTodoByActivityId: params.getTodoByActivityId,
+    getScheduleById: params.getScheduleById,
+    getScheduleByActivityId: params.getScheduleByActivityId,
+  };
 }
 
-/** 与 Planner 相同的 tag / 加星筛选；范围按 todo.id */
+function schedulePlannerTs(schedule: LedgerScheduleRef): number | undefined {
+  const due = schedule.activityDueRange?.[0];
+  return due != null ? due : undefined;
+}
+
+/** 优先 sourceTodoId / sourceScheduleId；云下载仅有 activity_id 时先 todo 后 schedule */
+export function resolveLedgerPlannerTs(entry: LedgerEntry, lookup: LedgerPlannerLookup): number | undefined {
+  if (entry.sourceScheduleId) {
+    const byId = lookup.getScheduleById?.(entry.sourceScheduleId);
+    const schedule = byId && !byId.deleted ? byId : lookup.getScheduleByActivityId?.(entry.sourceActivityId);
+    if (schedule && !schedule.deleted) {
+      const ts = schedulePlannerTs(schedule);
+      if (ts != null) return ts;
+    }
+  }
+
+  if (entry.sourceTodoId) {
+    const byTodoId = lookup.getTodoById(entry.sourceTodoId);
+    const todo = byTodoId && !byTodoId.deleted ? byTodoId : lookup.getTodoByActivityId?.(entry.sourceActivityId);
+    if (todo && !todo.deleted) return todo.id;
+  }
+
+  const todo = lookup.getTodoByActivityId?.(entry.sourceActivityId);
+  if (todo && !todo.deleted) return todo.id;
+
+  const schedule = lookup.getScheduleByActivityId?.(entry.sourceActivityId);
+  if (schedule && !schedule.deleted) return schedulePlannerTs(schedule);
+
+  return undefined;
+}
+
+/** 与 Planner 相同的 tag / 加星筛选；范围按 planner 时间戳 */
 export function filterLedgerEntries(params: LedgerQueryParams): LedgerEntry[] {
   const {
     entries,
@@ -110,15 +149,14 @@ export function filterLedgerEntries(params: LedgerQueryParams): LedgerEntry[] {
     rangeEnd,
     filterTagIds,
     filterStarredOnly,
-    getTodoById,
-    getTodoByActivityId,
     getActivityTagIds,
     hasStarredTaskForActivity,
   } = params;
+  const lookup = plannerLookup(params);
 
   return entries.filter((entry) => {
     if (entry.deleted) return false;
-    const plannerTs = resolveLedgerPlannerTs(entry, getTodoById, getTodoByActivityId);
+    const plannerTs = resolveLedgerPlannerTs(entry, lookup);
     if (plannerTs == null || plannerTs < rangeStart || plannerTs >= rangeEnd) return false;
     const activityId = entry.sourceActivityId;
     return matchesActivityFilter({
@@ -338,12 +376,11 @@ export function buildLedgerTrend(
   rangeStart: number,
   rangeEnd: number,
   viewScale: LedgerViewScale,
-  getTodoById: (todoId: number) => LedgerTodoRef | undefined,
-  getTodoByActivityId?: (activityId: number) => LedgerTodoRef | undefined,
+  lookup: LedgerPlannerLookup,
 ): LedgerTrendBucket[] {
   const buckets = buildTrendBuckets(rangeStart, rangeEnd, viewScale);
   for (const entry of entries) {
-    const plannerTs = resolveLedgerPlannerTs(entry, getTodoById, getTodoByActivityId);
+    const plannerTs = resolveLedgerPlannerTs(entry, lookup);
     if (plannerTs == null) continue;
     const idx = findTrendBucketIndex(buckets, plannerTs, viewScale);
     if (idx < 0) continue;
@@ -356,13 +393,12 @@ export function buildLedgerTrend(
 export function buildLedgerTableRows(
   entries: readonly LedgerEntry[],
   getTagName: (id: number) => string | undefined,
-  getTodoById: (todoId: number) => LedgerTodoRef | undefined,
+  lookup: LedgerPlannerLookup,
   sort: LedgerTableSort,
-  getTodoByActivityId?: (activityId: number) => LedgerTodoRef | undefined,
 ): LedgerTableRow[] {
   const rows: LedgerTableRow[] = [];
   for (const entry of entries) {
-    const plannerTs = resolveLedgerPlannerTs(entry, getTodoById, getTodoByActivityId);
+    const plannerTs = resolveLedgerPlannerTs(entry, lookup);
     if (plannerTs == null) continue;
     rows.push({
       id: entry.id,
@@ -380,6 +416,7 @@ export function buildLedgerTableRows(
 
 export function aggregateLedger(params: LedgerQueryParams, tableSort: LedgerTableSort = "time"): LedgerAggregateResult {
   const filtered = filterLedgerEntries(params);
+  const lookup = plannerLookup(params);
   const trendRange = resolveTrendQueryRange(params.rangeStart, params.rangeEnd, params.viewScale);
   const trendEntries =
     params.viewScale === "day"
@@ -388,21 +425,8 @@ export function aggregateLedger(params: LedgerQueryParams, tableSort: LedgerTabl
   return {
     stats: buildLedgerStats(filtered),
     pie: buildLedgerPie(filtered, params.getTagName),
-    trend: buildLedgerTrend(
-      trendEntries,
-      params.rangeStart,
-      params.rangeEnd,
-      params.viewScale,
-      params.getTodoById,
-      params.getTodoByActivityId,
-    ),
-    tableRows: buildLedgerTableRows(
-      filtered,
-      params.getTagName,
-      params.getTodoById,
-      tableSort,
-      params.getTodoByActivityId,
-    ),
+    trend: buildLedgerTrend(trendEntries, params.rangeStart, params.rangeEnd, params.viewScale, lookup),
+    tableRows: buildLedgerTableRows(filtered, params.getTagName, lookup, tableSort),
   };
 }
 

--- a/src/services/ledger/ledgerService.ts
+++ b/src/services/ledger/ledgerService.ts
@@ -9,9 +9,12 @@ import {
 
 export interface SyncLedgerFromTitleParams {
   activityId: number;
-  todoId: number;
   rawTitle: string;
   defaultCurrency: string;
+  /** todo 行保存时传入 */
+  todoId?: number;
+  /** schedule 行保存时传入 */
+  scheduleId?: number;
 }
 
 export interface SyncLedgerFromTitleResult {
@@ -89,7 +92,8 @@ export function syncLedgerFromTodoTitle(
         rawSegment: seg.rawSegment,
         segmentIndex: nextSegIdx++,
         sourceActivityId: params.activityId,
-        sourceTodoId: params.todoId,
+        sourceTodoId: params.todoId ?? 0,
+        sourceScheduleId: params.scheduleId ?? 0,
         deleted: false,
         synced: false,
         lastModified: now,

--- a/src/services/sync/ledgerSync.ts
+++ b/src/services/sync/ledgerSync.ts
@@ -42,8 +42,9 @@ export class LedgerSyncService extends BaseSyncService<LedgerEntry, CloudLedgerI
       rawSegment: cloud.raw_segment,
       segmentIndex: cloud.segment_index,
       sourceActivityId: cloud.activity_id,
-      // 云表不存 todo_id；与 activity 1:1，聚合时经 todoByActivityId 解析
+      // 云表不存 todo_id / schedule_id；与 activity 1:1，聚合时经 todoByActivityId / scheduleByActivityId 解析
       sourceTodoId: 0,
+      sourceScheduleId: 0,
       lastModified: Date.now(),
       cloudModified: cloudTimestamp,
       synced: true,

--- a/src/stores/useSyncStore.ts
+++ b/src/stores/useSyncStore.ts
@@ -6,6 +6,7 @@ import { useRouter } from "vue-router";
 import { signOut, getCurrentUser } from "@/core/services/authService";
 import { isSupabaseEnabled, supabase } from "@/core/services/supabase";
 import { destroyAppCloseHandler } from "@/services/platform/appCloseHandler";
+import { performIntentionalSignOut } from "@/core/auth/signedInSessionLifecycle";
 
 const shouldLogSyncDebug = ["1", "true"].includes(
   String(import.meta.env.VITE_SYNC_DEBUG_LOG ?? "")
@@ -220,18 +221,19 @@ export const useSyncStore = defineStore("sync", () => {
     loggingOut.value = true;
 
     try {
-      // 登出时先销毁同步服务
-      destroySyncService();
+      await performIntentionalSignOut(async () => {
+        destroySyncService();
 
-      // 必须用 supabase 实例判断：isSupabaseEnabled() 在 localOnlyMode 时为 false，会跳过 signOut，导致会话仍留在 localStorage，刷新又自动登录
-      if (!supabase) {
-        console.log("👋 无 Supabase 客户端，跳过远端 signOut");
-      } else {
-        console.log("👋 退出登录，切断同步连接");
-        await signOut();
-      }
+        // 必须用 supabase 实例判断：isSupabaseEnabled() 在 localOnlyMode 时为 false，会跳过 signOut，导致会话仍留在 localStorage，刷新又自动登录
+        if (!supabase) {
+          console.log("👋 无 Supabase 客户端，跳过远端 signOut");
+        } else {
+          console.log("👋 退出登录，切断同步连接");
+          await signOut();
+        }
 
-      destroyAppCloseHandler();
+        destroyAppCloseHandler();
+      });
       isLoggedIn.value = false;
     } catch (error) {
       console.error("退出登录时出错:", error);

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1556,6 +1556,25 @@ const {
     );
     return normalizedTitle;
   },
+  onScheduleTitleSaved(scheduleId, rawTitle) {
+    const schedule = scheduleById.value.get(scheduleId);
+    if (!schedule) return rawTitle;
+    const activity = activityById.value.get(schedule.activityId);
+    if (!activity) return rawTitle;
+    const { normalizedTitle } = syncLedgerFromTodoTitle(
+      ledgerList.value,
+      {
+        activityId: schedule.activityId,
+        scheduleId: schedule.id,
+        rawTitle,
+        defaultCurrency: settingStore.settings.defaultCurrency,
+      },
+      {
+        resolveOrCreateTagByName: (name) => tagStore.addTag(name, "#2080f0", "rgba(206, 227, 252, 0.5)").id,
+      },
+    );
+    return normalizedTitle;
+  },
 });
 
 function plannerKeyboardEditField(field: "title" | "start" | "done" | "duration" | "location"): boolean {

--- a/src/views/MainLayout.vue
+++ b/src/views/MainLayout.vue
@@ -453,6 +453,7 @@ async function handleLogoutConfirm() {
 async function handleLogoutCancel() {
   // 用户点击"不保留"，设置为不保留本地数据
   settingStore.settings.keepLocalDataAfterSignOut = false;
+  settingStore.settings.keepLocalDataOnNextSignOut = false;
   // 已登录时，退出前总是先执行一次完整同步；同步失败不阻断登出流程
   if (syncStore.isLoggedIn) {
     try {


### PR DESCRIPTION
- 修复不同尺度展示
- 增加schedule录入
- 修复退出删除数据失败
- 调整单行展示ui

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ledger date resolution and intentional logout sequencing; auth/storage interaction is sensitive but scoped and covered by new tests.
> 
> **Overview**
> Extends **ledger from schedule rows** the same way todos work: titles parse into entries with `sourceScheduleId`, aggregation dates use `activityDueRange[0]`, and **DaySchedule** shows wallet popover, ledger `#` tag mode, and delete-via-title updates.
> 
> **Ledger reporting** gains **year-scale** trend (12 fixed month buckets) and unified `LedgerPlannerLookup` so filter/trend/table resolve planner time from todo or schedule (including cloud rows with only `activity_id`). The aggregate panel wires in schedule maps and hardens visible-range resolution when refs are partially unwrapped.
> 
> **UI**: shared **`LedgerEntryPanel`** (category / memo / amount table); popover uses body teleport + flip/shift on desktop and a **centered modal** on mobile/narrow widths.
> 
> **Logout**: **`performIntentionalSignOut`** runs remote `signOut` then `applySignedOut`, skips duplicate `SIGNED_OUT` cleanup while intentional sign-out is in progress, and **reloads** when local data should be cleared—addressing sign-out vs storage clear races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986920268d5c9a381d21a4a0e1cb83c0788700e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->