### PR TITLE
[S1 C1 UV1] fix 记账展示iphone，tag 级联删除，修修改登出选择不再提供数据删除

### DIFF
--- a/src/__tests__/tagStore.test.ts
+++ b/src/__tests__/tagStore.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useTagStore } from "@/stores/useTagStore";
+import { useDataStore } from "@/stores/useDataStore";
+
+vi.mock("@/services/data/localStorageService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/data/localStorageService")>();
+  return {
+    ...actual,
+    loadTags: vi.fn(() => []),
+    saveTags: vi.fn(),
+    loadActivities: vi.fn(() => []),
+    loadTodos: vi.fn(() => []),
+    loadSchedules: vi.fn(() => []),
+    loadTasks: vi.fn(() => []),
+    loadTemplates: vi.fn(() => []),
+    loadLedgerEntries: vi.fn(() => []),
+  };
+});
+
+vi.mock("@/core/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/core/utils")>();
+  return {
+    ...actual,
+    scheduleDebouncedCloudUpload: vi.fn(),
+  };
+});
+
+vi.mock("@/stores/useSearchUiStore", () => ({
+  useSearchUiStore: vi.fn(() => ({
+    removeFilterTagId: vi.fn(),
+  })),
+}));
+
+describe("useTagStore.addTag", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("同毫秒创建多个新标签时 id 递增", () => {
+    const fixed = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(fixed);
+    const tagStore = useTagStore();
+
+    const a = tagStore.addTag("food", "#2080f0", "rgba(206, 227, 252, 0.5)");
+    const b = tagStore.addTag("transport", "#2080f0", "rgba(206, 227, 252, 0.5)");
+    const c = tagStore.addTag("salary", "#2080f0", "rgba(206, 227, 252, 0.5)");
+
+    expect(a.id).toBe(fixed);
+    expect(b.id).toBe(fixed + 1);
+    expect(c.id).toBe(fixed + 2);
+    expect(new Set([a.id, b.id, c.id]).size).toBe(3);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("useTagStore.removeTag", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("软删 tag 时从 activity 与 ledger 移除引用并标记 unsynced", () => {
+    const tagStore = useTagStore();
+    const dataStore = useDataStore();
+
+    tagStore.addTag("food", "#2080f0", "rgba(206, 227, 252, 0.5)");
+    const keepTag = tagStore.addTag("transport", "#2080f0", "rgba(206, 227, 252, 0.5)");
+    const foodId = tagStore.allTags.find((t) => t.name === "food")!.id;
+
+    dataStore.activityList.push({
+      id: 1,
+      title: "test",
+      class: "T",
+      parentId: null,
+      tagIds: [foodId, keepTag.id],
+      lastModified: 0,
+      synced: true,
+      deleted: false,
+    });
+    dataStore.ledgerList.push({
+      id: 1,
+      amount: 10,
+      direction: "expense",
+      currency: "CNY",
+      categoryTagIds: [foodId],
+      rawSegment: "-10 #food",
+      segmentIndex: 0,
+      sourceActivityId: 1,
+      sourceTodoId: 0,
+      lastModified: 0,
+      synced: true,
+      deleted: false,
+    });
+
+    tagStore.removeTag(foodId);
+
+    expect(tagStore.getTag(foodId)).toBeUndefined();
+    expect(dataStore.activityList[0].tagIds).toEqual([keepTag.id]);
+    expect(dataStore.activityList[0].synced).toBe(false);
+    expect(dataStore.ledgerList[0].categoryTagIds).toBeUndefined();
+    expect(dataStore.ledgerList[0].synced).toBe(false);
+  });
+});

--- a/src/components/Ledger/LedgerAggregatePopover.vue
+++ b/src/components/Ledger/LedgerAggregatePopover.vue
@@ -149,8 +149,8 @@ const modalStyle = computed(() =>
         width: "100vw",
         maxWidth: "100vw",
         margin: "0",
-        height: "calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))",
-        maxHeight: "calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))",
+        height: "calc(100dvh - env(safe-area-inset-top, 0px))",
+        maxHeight: "calc(100dvh - env(safe-area-inset-top, 0px))",
         display: "flex",
         flexDirection: "column",
       }
@@ -165,7 +165,7 @@ const modalContentStyle = computed(() =>
         overflow: "auto",
         overscrollBehavior: "contain",
         backgroundColor: "var(--n-color-modal)",
-        paddingBottom: "max(12px, env(safe-area-inset-bottom, 0px))",
+        paddingBottom: "12px",
       }
     : { maxHeight: "min(90vh, 840px)", overflow: "hidden" },
 );
@@ -445,8 +445,8 @@ ul.ledger-guide__body {
     margin-right: 0 !important;
     width: 100vw !important;
     max-width: 100vw !important;
-    height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-    max-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+    height: calc(100dvh - env(safe-area-inset-top, 0px)) !important;
+    max-height: calc(100dvh - env(safe-area-inset-top, 0px)) !important;
     display: flex !important;
     flex-direction: column !important;
     background-color: var(--n-color-modal) !important;

--- a/src/components/Ledger/LedgerAggregatePopover.vue
+++ b/src/components/Ledger/LedgerAggregatePopover.vue
@@ -143,9 +143,32 @@ const chartHeight = computed(() => (isMobile.value ? 160 : 220));
 
 const modalTitle = computed(() => `收支统计 · ${scaleLabel.value}视图`);
 
-const modalStyle = computed(() => (isMobile.value ? { width: "100vw", maxWidth: "100vw", margin: "0" } : { width: "min(1100px, 98vw)" }));
+const modalStyle = computed(() =>
+  isMobile.value
+    ? {
+        width: "100vw",
+        maxWidth: "100vw",
+        margin: "0",
+        height: "calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))",
+        maxHeight: "calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))",
+        display: "flex",
+        flexDirection: "column",
+      }
+    : { width: "min(1100px, 98vw)" },
+);
 
-const modalContentStyle = computed(() => (isMobile.value ? undefined : { maxHeight: "min(90vh, 840px)", overflow: "hidden" }));
+const modalContentStyle = computed(() =>
+  isMobile.value
+    ? {
+        flex: "1",
+        minHeight: "0",
+        overflow: "auto",
+        overscrollBehavior: "contain",
+        backgroundColor: "var(--n-color-modal)",
+        paddingBottom: "max(12px, env(safe-area-inset-bottom, 0px))",
+      }
+    : { maxHeight: "min(90vh, 840px)", overflow: "hidden" },
+);
 
 const netText = computed(() => {
   const n = aggregateData.value.stats.net;
@@ -413,7 +436,6 @@ ul.ledger-guide__body {
 }
 </style>
 
-<!-- modal teleport 到 body：iPhone 顶栏安全区 + 关闭 × 无灰底 -->
 <style>
 @media (max-width: 768px) {
   .n-modal-body-wrapper .ledger-aggregate-modal {
@@ -421,7 +443,40 @@ ul.ledger-guide__body {
     margin-top: env(safe-area-inset-top, 0px) !important;
     margin-left: 0 !important;
     margin-right: 0 !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
     max-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+    display: flex !important;
+    flex-direction: column !important;
+    background-color: var(--n-color-modal) !important;
+    border-radius: 0 !important;
+  }
+
+  .ledger-aggregate-modal .n-card-header {
+    flex-shrink: 0;
+    background-color: var(--n-color-modal) !important;
+  }
+
+  .ledger-aggregate-modal .n-card__content {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    background-color: var(--n-color-modal) !important;
+  }
+
+  .ledger-aggregate-modal .ledger-aggregate {
+    min-height: 100%;
+    background-color: var(--n-color-modal);
+  }
+
+  .ledger-aggregate-modal .ledger-aggregate__table-scroll {
+    max-height: none;
+    flex: 1;
+    min-height: 160px;
+    background-color: var(--n-color-modal);
   }
 }
 

--- a/src/components/Ledger/LedgerAggregatePopover.vue
+++ b/src/components/Ledger/LedgerAggregatePopover.vue
@@ -10,6 +10,7 @@
   <n-modal
     v-model:show="showModal"
     preset="card"
+    class="ledger-aggregate-modal"
     :title="modalTitle"
     :style="modalStyle"
     :content-style="modalContentStyle"
@@ -409,5 +410,26 @@ ul.ledger-guide__body {
 .ledger-aggregate--desktop .ledger-aggregate-table__tags {
   white-space: normal;
   word-break: break-word;
+}
+</style>
+
+<!-- modal teleport 到 body：iPhone 顶栏安全区 + 关闭 × 无灰底 -->
+<style>
+@media (max-width: 768px) {
+  .n-modal-body-wrapper .ledger-aggregate-modal {
+    align-self: flex-start !important;
+    margin-top: env(safe-area-inset-top, 0px) !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    max-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+  }
+}
+
+.ledger-aggregate-modal .n-base-close::before {
+  background-color: transparent !important;
+}
+
+.ledger-aggregate-modal .n-base-close:not(.n-base-close--disabled):hover::before {
+  background-color: transparent !important;
 }
 </style>

--- a/src/components/data/DatabaseTransferDialog.vue
+++ b/src/components/data/DatabaseTransferDialog.vue
@@ -78,7 +78,6 @@ import {
   type ImportReport,
 } from "@/services/data/mergeService";
 import { useSyncStore } from "@/stores/useSyncStore";
-import { useSettingStore } from "@/stores/useSettingStore";
 
 /** 跳过类行用灰色（depth 3），其余正常色 */
 function isSkippedReportLine(row: FileProcessResult): boolean {
@@ -110,7 +109,7 @@ const { exportData, message: exportMessage } = useDataExport();
 const isTauriRuntime = isTauri();
 const importButtonLabel = computed(() => (isTauriRuntime ? "预览导入（文件夹）" : "预览导入（文件夹）"));
 const syncStore = useSyncStore();
-const settingStore = useSettingStore();
+
 const canRestoreImportSnapshot = ref(hasImportRollbackSnapshot());
 
 function pauseImportSyncGateSafely(): void {

--- a/src/components/data/DatabaseTransferDialog.vue
+++ b/src/components/data/DatabaseTransferDialog.vue
@@ -230,8 +230,6 @@ async function handlePreviewImport() {
 
     // 导入预览前必须先退出登录，避免带登录态做导入引发同步覆盖风险
     if (syncStore.isLoggedIn) {
-      // 本次“为了导入预览而退出”必须保留本地数据，避免误清空
-      settingStore.settings.keepLocalDataOnNextSignOut = true;
       await syncStore.handleLogout();
       if (syncStore.isLoggedIn) {
         message.value = "请先退出登录后再进行导入预览。";

--- a/src/components/setting/SettingGeneralTab.vue
+++ b/src/components/setting/SettingGeneralTab.vue
@@ -60,9 +60,9 @@
           <template #trigger>
             <n-button size="small" type="error">清空本地数据</n-button>
           </template>
-          将清空当前设备上的本地业务数据与登录会话。
+          将清空本机上的业务数据与登录会话。
           <br />
-          本地数据不会被删除，重新登录后能会同步回来。
+          云端数据不会被删除，重新登录后会同步至本地。
           <br />
           确认继续吗？
         </n-popconfirm>

--- a/src/core/auth/signedInSessionLifecycle.ts
+++ b/src/core/auth/signedInSessionLifecycle.ts
@@ -188,59 +188,45 @@ export async function applySignedInSession(session: any, opts?: { backgroundSync
   return next;
 }
 
-/** 登出 reset 时保留的本地偏好（与账号无关） */
-function snapshotPlannerPriorityPrefs(settingStore: ReturnType<typeof useSettingStore>) {
-  return {
-    priorityCategoryTagIds: { ...settingStore.settings.priorityCategoryTagIds },
-    priorityCategoryShowInRank: { ...settingStore.settings.priorityCategoryShowInRank },
-  };
-}
-
-function restorePlannerPriorityPrefs(settingStore: ReturnType<typeof useSettingStore>, snap: ReturnType<typeof snapshotPlannerPriorityPrefs>) {
-  settingStore.settings.priorityCategoryTagIds = snap.priorityCategoryTagIds;
-  settingStore.settings.priorityCategoryShowInRank = snap.priorityCategoryShowInRank;
-}
-
 function hasSupabaseAuthStorage(): boolean {
   if (typeof localStorage === "undefined") return false;
   return Object.keys(localStorage).some((key) => key.startsWith("sb-"));
 }
 
-/**
- * 用户点击退出登录：先 signOut，再清本地；清除数据时 reload（与设置页「清空本地数据」一致）
- */
+/** 用户点击退出登录：先 signOut，再断会话；本机业务数据与同步游标保留 */
 export async function performIntentionalSignOut(signOutFn: () => Promise<void>): Promise<void> {
-  const settingStore = useSettingStore();
-  const keep = settingStore.settings.keepLocalDataAfterSignOut || settingStore.settings.keepLocalDataOnNextSignOut;
-
   intentionalSignOutInProgress = true;
   try {
     await signOutFn();
     await applySignedOut();
-    if (!keep) {
-      window.location.reload();
-    }
   } finally {
     intentionalSignOutInProgress = false;
   }
 }
 
-/** 登出清理（与 App 原逻辑一致） */
+/** 登出：断 Auth 会话与同步生命周期；保留 localStorage 业务数据、lastSync、lastLoggedInUserId */
 export async function applySignedOut(): Promise<void> {
   const settingStore = useSettingStore();
   const dataStore = useDataStore();
   const syncStore = useSyncStore();
 
-  appDebugLog("👋 用户已登出，清理同步状态和认证会话");
+  appDebugLog("👋 用户已登出，保留本机数据");
   syncStore.isLoggedIn = false;
-  const keep = settingStore.settings.keepLocalDataAfterSignOut || settingStore.settings.keepLocalDataOnNextSignOut;
-  settingStore.settings.keepLocalDataOnNextSignOut = false;
-  const priorityPrefs = snapshotPlannerPriorityPrefs(settingStore);
-  clearAllUserState(keep, true, !keep);
-  if (!keep) {
-    settingStore.resetSettings();
-    restorePlannerPriorityPrefs(settingStore, priorityPrefs);
+
+  cleanupSyncLifecycle();
+
+  dataStore.clearData();
+  if (typeof localStorage !== "undefined") {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("sb-")) {
+        localStorage.removeItem(key);
+      }
+    }
   }
+
+  syncStore.resetSyncState();
+  settingStore.settings.wasLocalModeBeforeLogin = false;
+
   await dataStore.loadAllData();
 }
 

--- a/src/stores/useDataStore.ts
+++ b/src/stores/useDataStore.ts
@@ -838,6 +838,41 @@ export const useDataStore = defineStore(
       return true;
     }
 
+    /** 软删 tag 时：从所有 activity / ledger 引用中移除该 id */
+    function stripTagIdFromReferences(tagId: number): void {
+      const now = Date.now();
+      let activitiesChanged = false;
+      let ledgerChanged = false;
+
+      for (const activity of activityList.value) {
+        if (!activity.tagIds?.includes(tagId)) continue;
+        const next = activity.tagIds.filter((id) => id !== tagId);
+        activity.tagIds = next.length > 0 ? next : undefined;
+        activity.lastModified = now;
+        activity.synced = false;
+        activitiesChanged = true;
+      }
+
+      for (const entry of ledgerList.value) {
+        if (!entry.categoryTagIds?.includes(tagId)) continue;
+        const next = entry.categoryTagIds.filter((id) => id !== tagId);
+        entry.categoryTagIds = next.length > 0 ? next : undefined;
+        entry.lastModified = now;
+        entry.synced = false;
+        ledgerChanged = true;
+      }
+
+      if (activitiesChanged) {
+        saveActivities(activityList.value);
+      }
+      if (ledgerChanged) {
+        saveLedgerEntries(ledgerList.value);
+      }
+      if (activitiesChanged || ledgerChanged) {
+        scheduleDebouncedCloudUpload();
+      }
+    }
+
     /**
      * 切换 Activity 的标签
      */
@@ -1132,6 +1167,7 @@ export const useDataStore = defineStore(
       toggleActivityTag,
       createAndAddTagToActivity,
       getActivityTags,
+      stripTagIdFromReferences,
 
       // Tag filter (day/week/month)
       toggleFilterTagId,

--- a/src/stores/useSettingStore.ts
+++ b/src/stores/useSettingStore.ts
@@ -65,8 +65,6 @@ export interface GlobalSettings {
   lastLoggedInUserId?: string; // 上次登录的用户ID，用于检测用户切换
   localOnlyMode: boolean; // 当前是否为本地模式
   wasLocalModeBeforeLogin: boolean; // 登录前是否是本地模式，用于退出时保护数据
-  keepLocalDataAfterSignOut: boolean; // 默认不清除本地数据
-  keepLocalDataOnNextSignOut: boolean; // 一次性开关：下一次退出登录强制保留本地数据
   isCompactMode: boolean; // 紧凑模式：只显示状态文字和时钟
   ai?: {
     activeId: number; // 当前启用的配置
@@ -137,8 +135,6 @@ const defaultSettings: GlobalSettings = {
   lastLoggedInUserId: undefined, // 首次使用，没有上次登录的用户ID
   localOnlyMode: false, // 默认不是本地模式
   wasLocalModeBeforeLogin: false, // 默认不是从本地模式切换过来的
-  keepLocalDataAfterSignOut: false, // 默认不清除本地数据
-  keepLocalDataOnNextSignOut: false, // 默认关闭一次性保留开关
   isCompactMode: false, // 默认不是紧凑模式
   priorityCategoryTagIds: {},
   priorityCategoryShowInRank: getDefaultPriorityCategoryShowInRank(),

--- a/src/stores/useTagStore.ts
+++ b/src/stores/useTagStore.ts
@@ -44,8 +44,8 @@ export const useTagStore = defineStore("tagStore", () => {
 
   /**
    * ✅ 主要的响应式 Getter，供所有 UI 使用。
-   * 它会自动关联 aсtivity 数据，计算出每个 tag 的 `count`。
-   * 当 aсtivities 或 tags 变化时，它会自动更新。
+   * 它会自动关联 activity 数据，计算出每个 tag 的 `count`。
+   * 当 activities 或 tags 变化时，它会自动更新。
    */
   const allTags = computed(() => {
     const countMap = new Map<number, number>();
@@ -89,6 +89,14 @@ export const useTagStore = defineStore("tagStore", () => {
     return rawTags.value.findIndex((t) => t.id === id);
   }
 
+  /** 分配新 id：以当前时间为基准，避开已有 id（同毫秒多标签递增） */
+  function allocateNextTagId(): number {
+    const used = new Set(rawTags.value.map((t) => t.id));
+    let candidate = Date.now();
+    while (used.has(candidate)) candidate++;
+    return candidate;
+  }
+
   /**
    * 添加一个新 tag。
    */
@@ -99,14 +107,15 @@ export const useTagStore = defineStore("tagStore", () => {
       return allTags.value.find((t) => t.id === existing.id)!;
     }
 
+    const id = allocateNextTagId();
     const newTag: Tag = {
-      id: Date.now(),
+      id,
       name: trimmedName,
       color,
       backgroundColor,
       deleted: false,
       synced: false, // 标记为需要同步
-      lastModified: Date.now(),
+      lastModified: id,
     };
 
     rawTags.value.push(newTag);
@@ -159,6 +168,7 @@ export const useTagStore = defineStore("tagStore", () => {
    */
   function removeTag(id: number) {
     updateTagById(id, { deleted: true });
+    dataStore.stripTagIdFromReferences(id);
     // 搜索页 filterTagIds 仍可能保留已删 id；getTag 已查不到标签导致筛选栏消失但列表仍被筛选
     useSearchUiStore().removeFilterTagId(id);
   }

--- a/src/views/MainLayout.vue
+++ b/src/views/MainLayout.vue
@@ -86,9 +86,8 @@
                 trigger="manual"
                 :on-clickoutside="handleLogoutPopconfirmClickOutside"
                 @positive-click="handleLogoutConfirm"
-                @negative-click="handleLogoutCancel"
-                negative-text="不保留"
-                positive-text="保留"
+                negative-text="取消"
+                positive-text="登出"
               >
                 <template #trigger>
                   <n-button
@@ -111,7 +110,7 @@
                     </template>
                   </n-button>
                 </template>
-                <span>退出登录时是否保留本地数据？</span>
+                <span>登出后本机数据仍保留；若要清空请前往设置 → 清空本地数据。确定登出？</span>
               </n-popconfirm>
             </div>
           </div>
@@ -433,10 +432,8 @@ onUnmounted(() => {
 // 底部同步条：非 mini、非移动端，且正在同步或存在同步错误时显示
 const showSyncFooter = computed(() => !isMiniMode.value && !isMobile.value && Boolean(syncStore.syncError));
 
-// 处理退出登录确认（保留数据）
+// 处理退出登录确认
 async function handleLogoutConfirm() {
-  // 用户点击"保留"，设置为保留本地数据
-  settingStore.settings.keepLocalDataAfterSignOut = true;
   // 已登录时，退出前总是先执行一次完整同步；同步失败不阻断登出流程
   if (syncStore.isLoggedIn) {
     try {
@@ -445,24 +442,6 @@ async function handleLogoutConfirm() {
       console.warn("[MainLayout] syncAll before logout failed:", error);
     }
   }
-  // 执行退出登录
-  await syncStore.handleLogout();
-}
-
-// 处理退出登录取消（不保留数据）
-async function handleLogoutCancel() {
-  // 用户点击"不保留"，设置为不保留本地数据
-  settingStore.settings.keepLocalDataAfterSignOut = false;
-  settingStore.settings.keepLocalDataOnNextSignOut = false;
-  // 已登录时，退出前总是先执行一次完整同步；同步失败不阻断登出流程
-  if (syncStore.isLoggedIn) {
-    try {
-      await syncAll();
-    } catch (error) {
-      console.warn("[MainLayout] syncAll before logout failed:", error);
-    }
-  }
-  // 执行退出登录
   await syncStore.handleLogout();
 }
 


### PR DESCRIPTION
- fix 登出保留数据出错，删除这个选项。删除数据放在设置
- fix iphone账本展示留边
- fix tag在账本中引用的级联删除

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 登出与本地数据生命周期行为变更，影响会话、同步与导入预览流程；标签删除会改写多条 activity/ledger 并触发上传。
> 
> **Overview**
> **登出**不再提供「是否保留本地数据」：移除 `keepLocalDataAfterSignOut` / `keepLocalDataOnNextSignOut` 及相关清空逻辑；`applySignedOut` 只断开同步与 Supabase 会话，再从 localStorage **重新加载**本机业务数据。头部与设置页的登出确认改为单一「登出」，并说明清空需走 **设置 → 清空本地数据**；导入预览前自动登出也不再设置一次性保留开关。
> 
> **标签**：软删时通过 `stripTagIdFromReferences` 从 activity 与 ledger 的 `tagIds` / `categoryTagIds` 中移除引用并标为未同步；新建标签用 `allocateNextTagId` 避免同毫秒 ID 冲突。新增 `tagStore` 单测覆盖上述行为。
> 
> **收支统计弹窗**在移动端改为全屏（`100dvh`、safe-area、可滚动内容），减少 iPhone 留边与布局问题。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4373306256066d7e811ae8007bfbc8b1894bda74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->